### PR TITLE
bugfix/Popover-close-on-scroll | adds touch event handler to the Root…

### DIFF
--- a/packages/react-kit/src/components/EventListener/EventListener.tsx
+++ b/packages/react-kit/src/components/EventListener/EventListener.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Component, ReactElement } from 'react';
 import { PURE } from '../../utils/pure';
+import { shallowEqual } from '@devexperts/utils/lib/object';
 
 type Handlers = {
 	[onEvent: string]: Function
@@ -22,12 +23,16 @@ export class EventListener extends Component<TEventListenerProps> {
 		this.addListeners();
 	}
 
-	componentWillUpdate() {
-		this.removeListeners();
+	componentWillUpdate(nextProps: TEventListenerProps) {
+		if (shouldResetListeners(this.props, nextProps)) {
+			this.removeListeners();
+		}
 	}
 
-	componentDidUpdate() {
-		this.addListeners();
+	componentDidUpdate(nextProps: TEventListenerProps) {
+		if (shouldResetListeners(this.props, nextProps)) {
+			this.addListeners();
+		}
 	}
 
 	componentWillUnmount() {
@@ -85,4 +90,10 @@ function getEventName(rawEventName: string, capture?: boolean): string {
 	const trimmedLeft = rawEventName.startsWith(ON_MARKER) ? rawEventName.substring(ON_MARKER.length) : rawEventName;
 	const trimmed = capture ? trimmedLeft.substring(0, trimmedLeft.length - CAPTURE_MARKER.length) : trimmedLeft;
 	return trimmed.toLowerCase();
+}
+
+function shouldResetListeners(prevProps: TEventListenerProps, nextProps: TEventListenerProps): boolean {
+	const {children: prevChildren, ...oldProps} = prevProps;
+	const {children: nextChildren, ...newProps} = nextProps;
+	return !shallowEqual(oldProps, newProps);
 }

--- a/packages/react-kit/src/components/EventListener/EventListener.tsx
+++ b/packages/react-kit/src/components/EventListener/EventListener.tsx
@@ -29,8 +29,8 @@ export class EventListener extends Component<TEventListenerProps> {
 		}
 	}
 
-	componentDidUpdate(nextProps: TEventListenerProps) {
-		if (shouldResetListeners(this.props, nextProps)) {
+	componentDidUpdate(prevProps: TEventListenerProps) {
+		if (shouldResetListeners(prevProps, this.props)) {
 			this.addListeners();
 		}
 	}

--- a/packages/react-kit/src/components/RootClose/RootClose.tsx
+++ b/packages/react-kit/src/components/RootClose/RootClose.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Component, KeyboardEventHandler, MouseEvent, MouseEventHandler, ReactElement } from 'react';
+import { Component, KeyboardEventHandler, MouseEvent, MouseEventHandler, ReactElement, TouchEventHandler } from 'react';
 import { EventListener } from '../EventListener/EventListener';
 import { findDOMNode } from 'react-dom';
 import { KeyCode } from '../Control/Control';
@@ -20,10 +20,13 @@ export class RootClose extends Component<TRootCloseProps> {
 
 	render() {
 		return (
-			<EventListener target={document}
-			               onClick={this.handleClick}
-			               onClickCapture={this.handleClickCapture}
-			               onKeyUp={this.handleKeyUp}>
+			<EventListener
+				target={document}
+				onClick={this.handleClick}
+				onClickCapture={this.handleClickCapture}
+				onTouchStart={this.handleTouchStart}
+				onTouchStartCapture={this.handleTouchStartCapture}
+				onKeyUp={this.handleKeyUp}>
 				{this.props.children}
 			</EventListener>
 		);
@@ -34,19 +37,29 @@ export class RootClose extends Component<TRootCloseProps> {
 			isModifiedEvent(e) ||
 			!isLeftClickEvent(e) ||
 			findDOMNode(this).contains(e.target as Node);
-	}
+	};
 
 	private handleClick: MouseEventHandler<HTMLElement> = e => {
 		if (!this.props.ignoreClick && !this.preventMouseRootClose && this.props.onRootClose) {
 			this.props.onRootClose();
 		}
-	}
+	};
+
+	private handleTouchStartCapture: TouchEventHandler<HTMLElement> = e => {
+		this.preventMouseRootClose = findDOMNode(this).contains(e.target as Node);
+	};
+
+	private handleTouchStart: TouchEventHandler<HTMLElement> = () => {
+		if (!this.props.ignoreClick && !this.preventMouseRootClose && this.props.onRootClose) {
+			this.props.onRootClose();
+		}
+	};
 
 	private handleKeyUp: KeyboardEventHandler<HTMLElement> = e => {
 		if (!this.props.ignoreKeyUp && e.keyCode === KeyCode.Escape && this.props.onRootClose) {
 			this.props.onRootClose();
 		}
-	}
+	};
 }
 
 function isLeftClickEvent(event: MouseEvent<HTMLElement>): boolean {


### PR DESCRIPTION
…Close; adds not children props check before update listeners