### PR TITLE
Unique symbol as symbol

### DIFF
--- a/packages/react-kit/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-kit/src/components/Autocomplete/Autocomplete.tsx
@@ -10,7 +10,7 @@ import { Pure } from '../Pure/Pure';
 import { KeyCode } from '../Control/Control';
 import { AutocompleteMenuItem, TAutocompleteMenuItemProps } from './AutocompleteMenuItem';
 
-export const AUTOCOMPLETE= Symbol('Autocomplete') as symbol;
+export const AUTOCOMPLETE = Symbol('Autocomplete') as symbol;
 
 export type TFullAutocompleteProps = TInputProps & {
 	Input: ComponentClass<TInputProps>;

--- a/packages/react-kit/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-kit/src/components/Autocomplete/Autocomplete.tsx
@@ -10,7 +10,7 @@ import { Pure } from '../Pure/Pure';
 import { KeyCode } from '../Control/Control';
 import { AutocompleteMenuItem, TAutocompleteMenuItemProps } from './AutocompleteMenuItem';
 
-export const AUTOCOMPLETE = Symbol('Autocomplete');
+export const AUTOCOMPLETE= Symbol('Autocomplete') as symbol;
 
 export type TFullAutocompleteProps = TInputProps & {
 	Input: ComponentClass<TInputProps>;

--- a/packages/react-kit/src/components/Autocomplete/AutocompleteMenuItem.tsx
+++ b/packages/react-kit/src/components/Autocomplete/AutocompleteMenuItem.tsx
@@ -5,7 +5,7 @@ import { ComponentClass } from 'react';
 import { withTheme } from '../../utils/withTheme';
 import { MenuItem, TMenuItemProps } from '../Menu/Menu';
 import { Highlight, THighlightProps } from '../Highlight/Highlight';
-const AUTOCOMPLETE_MENU_ITEM= Symbol('AutocompleteMenuItem') as symbol;
+const AUTOCOMPLETE_MENU_ITEM = Symbol('AutocompleteMenuItem') as symbol;
 
 export type TFullAutocompleteMenuItemProps = TMenuItemProps & {
 	search: string;

--- a/packages/react-kit/src/components/Autocomplete/AutocompleteMenuItem.tsx
+++ b/packages/react-kit/src/components/Autocomplete/AutocompleteMenuItem.tsx
@@ -5,7 +5,7 @@ import { ComponentClass } from 'react';
 import { withTheme } from '../../utils/withTheme';
 import { MenuItem, TMenuItemProps } from '../Menu/Menu';
 import { Highlight, THighlightProps } from '../Highlight/Highlight';
-const AUTOCOMPLETE_MENU_ITEM = Symbol('AutocompleteMenuItem');
+const AUTOCOMPLETE_MENU_ITEM= Symbol('AutocompleteMenuItem') as symbol;
 
 export type TFullAutocompleteMenuItemProps = TMenuItemProps & {
 	search: string;

--- a/packages/react-kit/src/components/Button/Button.tsx
+++ b/packages/react-kit/src/components/Button/Button.tsx
@@ -7,7 +7,7 @@ import { ComponentClass, EventHandler, MouseEvent } from 'react';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ObjectClean } from 'typelevel-ts';
 
-export const BUTTON= Symbol('Button') as symbol;
+export const BUTTON = Symbol('Button') as symbol;
 
 export type TFullButtonProps = {
 	theme: {

--- a/packages/react-kit/src/components/Button/Button.tsx
+++ b/packages/react-kit/src/components/Button/Button.tsx
@@ -7,7 +7,7 @@ import { ComponentClass, EventHandler, MouseEvent } from 'react';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ObjectClean } from 'typelevel-ts';
 
-export const BUTTON = Symbol('Button');
+export const BUTTON= Symbol('Button') as symbol;
 
 export type TFullButtonProps = {
 	theme: {

--- a/packages/react-kit/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/react-kit/src/components/ButtonIcon/ButtonIcon.tsx
@@ -6,7 +6,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const BUTTON_ICON = Symbol('ButtonIcon');
+export const BUTTON_ICON= Symbol('ButtonIcon') as symbol;
 
 export type TFullButtonIconProps = ObjectClean<
 	TButtonProps & {

--- a/packages/react-kit/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/react-kit/src/components/ButtonIcon/ButtonIcon.tsx
@@ -6,7 +6,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const BUTTON_ICON= Symbol('ButtonIcon') as symbol;
+export const BUTTON_ICON = Symbol('ButtonIcon') as symbol;
 
 export type TFullButtonIconProps = ObjectClean<
 	TButtonProps & {

--- a/packages/react-kit/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-kit/src/components/Checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
-export const CHECKBOX = Symbol('Checkbox');
+export const CHECKBOX= Symbol('Checkbox') as symbol;
 
 export type TFullCheckboxProps = TControlProps<boolean> & {
 	id?: string;

--- a/packages/react-kit/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-kit/src/components/Checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
-export const CHECKBOX= Symbol('Checkbox') as symbol;
+export const CHECKBOX = Symbol('Checkbox') as symbol;
 
 export type TFullCheckboxProps = TControlProps<boolean> & {
 	id?: string;

--- a/packages/react-kit/src/components/DateInput/DateInput.tsx
+++ b/packages/react-kit/src/components/DateInput/DateInput.tsx
@@ -67,7 +67,7 @@ type TDateInputState = {
 	isOpened?: boolean;
 };
 
-export const DATE_INPUT = Symbol('DateInput');
+export const DATE_INPUT= Symbol('DateInput') as symbol;
 
 @PURE
 class RawDateInput extends React.Component<TDateInputFullProps, TDateInputState> {

--- a/packages/react-kit/src/components/DateInput/DateInput.tsx
+++ b/packages/react-kit/src/components/DateInput/DateInput.tsx
@@ -67,7 +67,7 @@ type TDateInputState = {
 	isOpened?: boolean;
 };
 
-export const DATE_INPUT= Symbol('DateInput') as symbol;
+export const DATE_INPUT = Symbol('DateInput') as symbol;
 
 @PURE
 class RawDateInput extends React.Component<TDateInputFullProps, TDateInputState> {

--- a/packages/react-kit/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-kit/src/components/Dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
-export const DROPDOWN = Symbol('Dropdown');
+export const DROPDOWN= Symbol('Dropdown') as symbol;
 
 export type TAnchorProps = WithInnerRef<{
 	onClick: MouseEventHandler<Element>;

--- a/packages/react-kit/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-kit/src/components/Dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
-export const DROPDOWN= Symbol('Dropdown') as symbol;
+export const DROPDOWN = Symbol('Dropdown') as symbol;
 
 export type TAnchorProps = WithInnerRef<{
 	onClick: MouseEventHandler<Element>;

--- a/packages/react-kit/src/components/Expandable/Expandable.tsx
+++ b/packages/react-kit/src/components/Expandable/Expandable.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
-export const EXPANDABLE= Symbol('Expandable') as symbol;
+export const EXPANDABLE = Symbol('Expandable') as symbol;
 
 export type TFullExpandableProps = TControlProps<boolean | null> & {
 	theme: {

--- a/packages/react-kit/src/components/Expandable/Expandable.tsx
+++ b/packages/react-kit/src/components/Expandable/Expandable.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
-export const EXPANDABLE = Symbol('Expandable');
+export const EXPANDABLE= Symbol('Expandable') as symbol;
 
 export type TFullExpandableProps = TControlProps<boolean | null> & {
 	theme: {

--- a/packages/react-kit/src/components/Grid/Grid.tsx
+++ b/packages/react-kit/src/components/Grid/Grid.tsx
@@ -28,7 +28,7 @@ import { ObjectClean, ObjectOmit } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
-export const GRID = Symbol('Grid');
+export const GRID= Symbol('Grid') as symbol;
 
 const EVENT_GRID = {
 	BODY_SCROLL: 'EVENT_GRID:BODY_SCROLL',

--- a/packages/react-kit/src/components/Grid/Grid.tsx
+++ b/packages/react-kit/src/components/Grid/Grid.tsx
@@ -28,7 +28,7 @@ import { ObjectClean, ObjectOmit } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
-export const GRID= Symbol('Grid') as symbol;
+export const GRID = Symbol('Grid') as symbol;
 
 const EVENT_GRID = {
 	BODY_SCROLL: 'EVENT_GRID:BODY_SCROLL',

--- a/packages/react-kit/src/components/Highlight/Highlight.tsx
+++ b/packages/react-kit/src/components/Highlight/Highlight.tsx
@@ -6,7 +6,7 @@ import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ObjectClean } from 'typelevel-ts/lib';
 import { ComponentClass, ReactNode } from 'react';
 
-export const HIGHLIGHT = Symbol('Mark');
+export const HIGHLIGHT= Symbol('Mark') as symbol;
 
 export type TFullHighlightProps = {
 	search: string;

--- a/packages/react-kit/src/components/Highlight/Highlight.tsx
+++ b/packages/react-kit/src/components/Highlight/Highlight.tsx
@@ -6,7 +6,7 @@ import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ObjectClean } from 'typelevel-ts/lib';
 import { ComponentClass, ReactNode } from 'react';
 
-export const HIGHLIGHT= Symbol('Mark') as symbol;
+export const HIGHLIGHT = Symbol('Mark') as symbol;
 
 export type TFullHighlightProps = {
 	search: string;

--- a/packages/react-kit/src/components/Link/Link.tsx
+++ b/packages/react-kit/src/components/Link/Link.tsx
@@ -6,7 +6,7 @@ import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ObjectClean } from 'typelevel-ts/lib';
 
-export const LINK = Symbol('Link');
+export const LINK= Symbol('Link') as symbol;
 
 export type TFullLinkProps = {
 	children: React.ReactNode;

--- a/packages/react-kit/src/components/Link/Link.tsx
+++ b/packages/react-kit/src/components/Link/Link.tsx
@@ -6,7 +6,7 @@ import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ObjectClean } from 'typelevel-ts/lib';
 
-export const LINK= Symbol('Link') as symbol;
+export const LINK = Symbol('Link') as symbol;
 
 export type TFullLinkProps = {
 	children: React.ReactNode;

--- a/packages/react-kit/src/components/List/List.tsx
+++ b/packages/react-kit/src/components/List/List.tsx
@@ -6,7 +6,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { PURE } from '../../utils/pure';
 
-export const LIST= Symbol('List') as symbol;
+export const LIST = Symbol('List') as symbol;
 const CONTEXT_LEVEL_KEY = '__LIST_CONTEXT_LEVEL_KEY__';
 const CONTEXT_TYPES: any = {
 	[CONTEXT_LEVEL_KEY]() {},

--- a/packages/react-kit/src/components/List/List.tsx
+++ b/packages/react-kit/src/components/List/List.tsx
@@ -6,7 +6,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { PURE } from '../../utils/pure';
 
-export const LIST = Symbol('List');
+export const LIST= Symbol('List') as symbol;
 const CONTEXT_LEVEL_KEY = '__LIST_CONTEXT_LEVEL_KEY__';
 const CONTEXT_TYPES: any = {
 	[CONTEXT_LEVEL_KEY]() {},

--- a/packages/react-kit/src/components/LoadingIndication/LoadingIndication.tsx
+++ b/packages/react-kit/src/components/LoadingIndication/LoadingIndication.tsx
@@ -8,7 +8,7 @@ import { LoadingIndicator, TLoadingIndicatorProps } from '../LoadingIndicator/Lo
 import { PURE } from '../../utils/pure';
 import * as cn from 'classnames';
 
-export const LOADING_INDICATION = Symbol('LoadingIndicaton');
+export const LOADING_INDICATION= Symbol('LoadingIndicaton') as symbol;
 
 export type TRawLoadingIndicatonProps = {
 	isVisible?: boolean;

--- a/packages/react-kit/src/components/LoadingIndication/LoadingIndication.tsx
+++ b/packages/react-kit/src/components/LoadingIndication/LoadingIndication.tsx
@@ -8,7 +8,7 @@ import { LoadingIndicator, TLoadingIndicatorProps } from '../LoadingIndicator/Lo
 import { PURE } from '../../utils/pure';
 import * as cn from 'classnames';
 
-export const LOADING_INDICATION= Symbol('LoadingIndicaton') as symbol;
+export const LOADING_INDICATION = Symbol('LoadingIndicaton') as symbol;
 
 export type TRawLoadingIndicatonProps = {
 	isVisible?: boolean;

--- a/packages/react-kit/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/packages/react-kit/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -5,7 +5,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass } from 'react';
 
-export const LOADING_INDICATOR= Symbol('LoadingIndicator') as symbol;
+export const LOADING_INDICATOR = Symbol('LoadingIndicator') as symbol;
 
 export type TFullLoadingIndicatorProps = {
 	theme: {

--- a/packages/react-kit/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/packages/react-kit/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -5,7 +5,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass } from 'react';
 
-export const LOADING_INDICATOR = Symbol('LoadingIndicator');
+export const LOADING_INDICATOR= Symbol('LoadingIndicator') as symbol;
 
 export type TFullLoadingIndicatorProps = {
 	theme: {

--- a/packages/react-kit/src/components/Menu/Menu.tsx
+++ b/packages/react-kit/src/components/Menu/Menu.tsx
@@ -19,7 +19,7 @@ import * as classnames from 'classnames';
 import { Pure } from '../Pure/Pure';
 import { ReactChildren } from '../../utils/typings';
 
-export const MENU = Symbol('Menu');
+export const MENU= Symbol('Menu') as symbol;
 
 export type TMenuChildProps = {
 	onSelect?: (value: ReactText) => void;

--- a/packages/react-kit/src/components/Menu/Menu.tsx
+++ b/packages/react-kit/src/components/Menu/Menu.tsx
@@ -19,7 +19,7 @@ import * as classnames from 'classnames';
 import { Pure } from '../Pure/Pure';
 import { ReactChildren } from '../../utils/typings';
 
-export const MENU= Symbol('Menu') as symbol;
+export const MENU = Symbol('Menu') as symbol;
 
 export type TMenuChildProps = {
 	onSelect?: (value: ReactText) => void;

--- a/packages/react-kit/src/components/NumericStepper/NumericStepper.tsx
+++ b/packages/react-kit/src/components/NumericStepper/NumericStepper.tsx
@@ -7,7 +7,7 @@ import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass } from 'react';
 import { Input, TInputProps } from '../input/Input';
 
-export const NUMERIC_STEPPER = Symbol('NumericStepper');
+export const NUMERIC_STEPPER= Symbol('NumericStepper') as symbol;
 
 export type TNumericStepperOwnProps = TSteppableInputProps &
 	TControlProps<any> & {

--- a/packages/react-kit/src/components/NumericStepper/NumericStepper.tsx
+++ b/packages/react-kit/src/components/NumericStepper/NumericStepper.tsx
@@ -7,7 +7,7 @@ import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass } from 'react';
 import { Input, TInputProps } from '../input/Input';
 
-export const NUMERIC_STEPPER= Symbol('NumericStepper') as symbol;
+export const NUMERIC_STEPPER = Symbol('NumericStepper') as symbol;
 
 export type TNumericStepperOwnProps = TSteppableInputProps &
 	TControlProps<any> & {

--- a/packages/react-kit/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-kit/src/components/PasswordInput/PasswordInput.tsx
@@ -7,7 +7,7 @@ import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentType } from 'react';
 
-export const PASSWORD_INPUT= Symbol('PasswordInput') as symbol;
+export const PASSWORD_INPUT = Symbol('PasswordInput') as symbol;
 
 export type TFullPasswordInputProps = TInputProps & {
 	theme: {

--- a/packages/react-kit/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-kit/src/components/PasswordInput/PasswordInput.tsx
@@ -7,7 +7,7 @@ import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentType } from 'react';
 
-export const PASSWORD_INPUT = Symbol('PasswordInput');
+export const PASSWORD_INPUT= Symbol('PasswordInput') as symbol;
 
 export type TFullPasswordInputProps = TInputProps & {
 	theme: {

--- a/packages/react-kit/src/components/Popover/Popover.tsx
+++ b/packages/react-kit/src/components/Popover/Popover.tsx
@@ -21,7 +21,7 @@ type TSize = {
 	height: number;
 };
 
-export const POPOVER = Symbol('Popover');
+export const POPOVER= Symbol('Popover') as symbol;
 
 export enum PopoverPlacement {
 	Top = 'Top',

--- a/packages/react-kit/src/components/Popover/Popover.tsx
+++ b/packages/react-kit/src/components/Popover/Popover.tsx
@@ -21,7 +21,7 @@ type TSize = {
 	height: number;
 };
 
-export const POPOVER= Symbol('Popover') as symbol;
+export const POPOVER = Symbol('Popover') as symbol;
 
 export enum PopoverPlacement {
 	Top = 'Top',

--- a/packages/react-kit/src/components/Popup/Popup.tsx
+++ b/packages/react-kit/src/components/Popup/Popup.tsx
@@ -8,7 +8,7 @@ import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 import { RootClose } from '../RootClose/RootClose';
 
-export const POPUP = Symbol('Popup');
+export const POPUP= Symbol('Popup') as symbol;
 
 export type TRawPopupProps = {
 	theme: {

--- a/packages/react-kit/src/components/Popup/Popup.tsx
+++ b/packages/react-kit/src/components/Popup/Popup.tsx
@@ -8,7 +8,7 @@ import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 import { RootClose } from '../RootClose/RootClose';
 
-export const POPUP= Symbol('Popup') as symbol;
+export const POPUP = Symbol('Popup') as symbol;
 
 export type TRawPopupProps = {
 	theme: {

--- a/packages/react-kit/src/components/ResizeDetector/ResizeDetector.tsx
+++ b/packages/react-kit/src/components/ResizeDetector/ResizeDetector.tsx
@@ -12,7 +12,7 @@ export const NativeResizeDetector = detectorFactory({
 	strategy: 'scroll',
 });
 
-export const RESIZE_DETECTOR= Symbol('ResizeDetector') as symbol;
+export const RESIZE_DETECTOR = Symbol('ResizeDetector') as symbol;
 
 export type TFullResizeDetectorProps = {
 	theme: {

--- a/packages/react-kit/src/components/ResizeDetector/ResizeDetector.tsx
+++ b/packages/react-kit/src/components/ResizeDetector/ResizeDetector.tsx
@@ -12,7 +12,7 @@ export const NativeResizeDetector = detectorFactory({
 	strategy: 'scroll',
 });
 
-export const RESIZE_DETECTOR = Symbol('ResizeDetector');
+export const RESIZE_DETECTOR= Symbol('ResizeDetector') as symbol;
 
 export type TFullResizeDetectorProps = {
 	theme: {

--- a/packages/react-kit/src/components/Scrollable/Scrollable.tsx
+++ b/packages/react-kit/src/components/Scrollable/Scrollable.tsx
@@ -21,7 +21,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const SCROLLABLE = Symbol('Scrollable');
+export const SCROLLABLE= Symbol('Scrollable') as symbol;
 
 export type TFullScrollableProps = {
 	children: React.ReactNode;

--- a/packages/react-kit/src/components/Scrollable/Scrollable.tsx
+++ b/packages/react-kit/src/components/Scrollable/Scrollable.tsx
@@ -21,7 +21,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const SCROLLABLE= Symbol('Scrollable') as symbol;
+export const SCROLLABLE = Symbol('Scrollable') as symbol;
 
 export type TFullScrollableProps = {
 	children: React.ReactNode;

--- a/packages/react-kit/src/components/Scrollbar/HorizontalScrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/HorizontalScrollbar.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
-export const HORIZONTAL_SCROLLBAR = Symbol('HorizontalScrollbar');
+export const HORIZONTAL_SCROLLBAR= Symbol('HorizontalScrollbar') as symbol;
 
 export type TAdditionalHorizontalProps = {
 	scrollLeft?: number;

--- a/packages/react-kit/src/components/Scrollbar/HorizontalScrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/HorizontalScrollbar.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
-export const HORIZONTAL_SCROLLBAR= Symbol('HorizontalScrollbar') as symbol;
+export const HORIZONTAL_SCROLLBAR = Symbol('HorizontalScrollbar') as symbol;
 
 export type TAdditionalHorizontalProps = {
 	scrollLeft?: number;

--- a/packages/react-kit/src/components/Scrollbar/VerticalScrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/VerticalScrollbar.tsx
@@ -6,7 +6,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const VERTICAL_SCROLLBAR= Symbol('VerticalScrollbar') as symbol;
+export const VERTICAL_SCROLLBAR = Symbol('VerticalScrollbar') as symbol;
 
 export type TAdditionalVerticalScrollBarProp = {
 	scrollTop?: number;

--- a/packages/react-kit/src/components/Scrollbar/VerticalScrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/VerticalScrollbar.tsx
@@ -6,7 +6,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const VERTICAL_SCROLLBAR = Symbol('VerticalScrollbar');
+export const VERTICAL_SCROLLBAR= Symbol('VerticalScrollbar') as symbol;
 
 export type TAdditionalVerticalScrollBarProp = {
 	scrollTop?: number;

--- a/packages/react-kit/src/components/Selectbox/Selectbox.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.tsx
@@ -13,7 +13,7 @@ import { NativeResizeDetector } from '../ResizeDetector/ResizeDetector';
 import { findDOMNode } from 'react-dom';
 import { raf } from '@devexperts/utils/dist/function/raf';
 
-export const SELECTBOX = Symbol('Selectbox');
+export const SELECTBOX= Symbol('Selectbox') as symbol;
 
 export type TFullSelectboxProps = TControlProps<ReactText> & {
 	theme: {

--- a/packages/react-kit/src/components/Selectbox/Selectbox.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.tsx
@@ -13,7 +13,7 @@ import { NativeResizeDetector } from '../ResizeDetector/ResizeDetector';
 import { findDOMNode } from 'react-dom';
 import { raf } from '@devexperts/utils/dist/function/raf';
 
-export const SELECTBOX= Symbol('Selectbox') as symbol;
+export const SELECTBOX = Symbol('Selectbox') as symbol;
 
 export type TFullSelectboxProps = TControlProps<ReactText> & {
 	theme: {

--- a/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
+++ b/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
@@ -10,7 +10,7 @@ import { Input, TInputProps } from '../input/Input';
 import { KeyCode } from '../Control/Control';
 import { Holdable } from '../Holdable/Holdable';
 
-export const STEPPABLE_INPUT= Symbol('SteppableInput') as symbol;
+export const STEPPABLE_INPUT = Symbol('SteppableInput') as symbol;
 
 export type TPickedInputProps = Pick<TInputProps, 'error' | 'onBlur' | 'onFocus' | 'onKeyDown' | 'onClick'>;
 

--- a/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
+++ b/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
@@ -10,7 +10,7 @@ import { Input, TInputProps } from '../input/Input';
 import { KeyCode } from '../Control/Control';
 import { Holdable } from '../Holdable/Holdable';
 
-export const STEPPABLE_INPUT = Symbol('SteppableInput');
+export const STEPPABLE_INPUT= Symbol('SteppableInput') as symbol;
 
 export type TPickedInputProps = Pick<TInputProps, 'error' | 'onBlur' | 'onFocus' | 'onKeyDown' | 'onClick'>;
 

--- a/packages/react-kit/src/components/Table/Table.tsx
+++ b/packages/react-kit/src/components/Table/Table.tsx
@@ -5,7 +5,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts/lib';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const TABLE = Symbol('Table');
+export const TABLE= Symbol('Table') as symbol;
 
 export type TTableTheme = {
 	container?: string;

--- a/packages/react-kit/src/components/Table/Table.tsx
+++ b/packages/react-kit/src/components/Table/Table.tsx
@@ -5,7 +5,7 @@ import { withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts/lib';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const TABLE= Symbol('Table') as symbol;
+export const TABLE = Symbol('Table') as symbol;
 
 export type TTableTheme = {
 	container?: string;

--- a/packages/react-kit/src/components/TimeInput/TimeInput.tsx
+++ b/packages/react-kit/src/components/TimeInput/TimeInput.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { SteppableInput, TSteppableInputProps } from '../SteppableInput/SteppableInput';
 
-export const TIME_INPUT= Symbol('TimeInput') as symbol;
+export const TIME_INPUT = Symbol('TimeInput') as symbol;
 
 export type TTime = {
 	hours: number;

--- a/packages/react-kit/src/components/TimeInput/TimeInput.tsx
+++ b/packages/react-kit/src/components/TimeInput/TimeInput.tsx
@@ -8,7 +8,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { SteppableInput, TSteppableInputProps } from '../SteppableInput/SteppableInput';
 
-export const TIME_INPUT = Symbol('TimeInput');
+export const TIME_INPUT= Symbol('TimeInput') as symbol;
 
 export type TTime = {
 	hours: number;

--- a/packages/react-kit/src/components/ToggleButtons/ToggleButtons.tsx
+++ b/packages/react-kit/src/components/ToggleButtons/ToggleButtons.tsx
@@ -6,7 +6,7 @@ import { mergeThemes, withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const TOGGLE_BUTTONS= Symbol('ToggleButtons') as symbol;
+export const TOGGLE_BUTTONS = Symbol('ToggleButtons') as symbol;
 
 export type TToggleButtonsChildProps = {
 	isActive?: boolean | undefined;

--- a/packages/react-kit/src/components/ToggleButtons/ToggleButtons.tsx
+++ b/packages/react-kit/src/components/ToggleButtons/ToggleButtons.tsx
@@ -6,7 +6,7 @@ import { mergeThemes, withTheme } from '../../utils/withTheme';
 import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
-export const TOGGLE_BUTTONS = Symbol('ToggleButtons');
+export const TOGGLE_BUTTONS= Symbol('ToggleButtons') as symbol;
 
 export type TToggleButtonsChildProps = {
 	isActive?: boolean | undefined;

--- a/packages/react-kit/src/components/input/Input.tsx
+++ b/packages/react-kit/src/components/input/Input.tsx
@@ -15,7 +15,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
-export const INPUT = Symbol('Input');
+export const INPUT= Symbol('Input') as symbol;
 
 export type TFullInputProps = TControlProps<string> & {
 	min?: any;

--- a/packages/react-kit/src/components/input/Input.tsx
+++ b/packages/react-kit/src/components/input/Input.tsx
@@ -15,7 +15,7 @@ import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
-export const INPUT= Symbol('Input') as symbol;
+export const INPUT = Symbol('Input') as symbol;
 
 export type TFullInputProps = TControlProps<string> & {
 	min?: any;

--- a/packages/react-kit/src/utils/__private__/shared.ts
+++ b/packages/react-kit/src/utils/__private__/shared.ts
@@ -2,4 +2,4 @@
  * Stores original css module and indicates that css object should be checked for equality in {@link PURE} components
  * @type {Symbol}
  */
-export const CSS_DECORATOR_STORAGE= Symbol('CSS_DECORATOR_STORAGE') as symbol;
+export const CSS_DECORATOR_STORAGE = Symbol('CSS_DECORATOR_STORAGE') as symbol;

--- a/packages/react-kit/src/utils/__private__/shared.ts
+++ b/packages/react-kit/src/utils/__private__/shared.ts
@@ -2,4 +2,4 @@
  * Stores original css module and indicates that css object should be checked for equality in {@link PURE} components
  * @type {Symbol}
  */
-export const CSS_DECORATOR_STORAGE = Symbol('CSS_DECORATOR_STORAGE');
+export const CSS_DECORATOR_STORAGE= Symbol('CSS_DECORATOR_STORAGE') as symbol;

--- a/packages/react-kit/src/utils/css.ts
+++ b/packages/react-kit/src/utils/css.ts
@@ -4,7 +4,7 @@ import { CSS_DECORATOR_STORAGE } from './__private__/shared';
  * Indicates that lifecycle method is overridden by {@link @CSS} decorator
  * @type {Symbol}
  */
-const CSS_DECORATOR_OVERRIDE_MARKER= Symbol('CSS_DECORATOR_OVERRIDE_MARKER') as symbol;
+const CSS_DECORATOR_OVERRIDE_MARKER = Symbol('CSS_DECORATOR_OVERRIDE_MARKER') as symbol;
 
 const CONTEXT = {};
 

--- a/packages/react-kit/src/utils/css.ts
+++ b/packages/react-kit/src/utils/css.ts
@@ -4,7 +4,7 @@ import { CSS_DECORATOR_STORAGE } from './__private__/shared';
  * Indicates that lifecycle method is overridden by {@link @CSS} decorator
  * @type {Symbol}
  */
-const CSS_DECORATOR_OVERRIDE_MARKER = Symbol('CSS_DECORATOR_OVERRIDE_MARKER');
+const CSS_DECORATOR_OVERRIDE_MARKER= Symbol('CSS_DECORATOR_OVERRIDE_MARKER') as symbol;
 
 const CONTEXT = {};
 

--- a/packages/utils/src/function/memoize.ts
+++ b/packages/utils/src/function/memoize.ts
@@ -1,7 +1,7 @@
 /**
  * @type {Symbol}
  */
-export const MEMOIZE_CLEAR_FUNCTION= Symbol('MEMOIZE_CLEAR_FUNCTION') as symbol;
+export const MEMOIZE_CLEAR_FUNCTION = Symbol('MEMOIZE_CLEAR_FUNCTION') as symbol;
 
 /**
  * Memoizes function for passed arguments

--- a/packages/utils/src/function/memoize.ts
+++ b/packages/utils/src/function/memoize.ts
@@ -1,7 +1,7 @@
 /**
  * @type {Symbol}
  */
-export const MEMOIZE_CLEAR_FUNCTION = Symbol('MEMOIZE_CLEAR_FUNCTION');
+export const MEMOIZE_CLEAR_FUNCTION= Symbol('MEMOIZE_CLEAR_FUNCTION') as symbol;
 
 /**
  * Memoizes function for passed arguments


### PR DESCRIPTION
from TS 2.7 expression `Symbol()` has type `unique symbol`. We temporarily need to use dx-platform in the project with TS 2.6 which is not aware of `unique` keyword. For not having `unique symbol` in d.ts files of dx-platform I suggest for now explicitly cast `Symbol() as symbol`.