### PR TITLE
Bring back optional container prop for Popover and Popup

### DIFF
--- a/packages/react-kit/src/components/Popover/Popover.tsx
+++ b/packages/react-kit/src/components/Popover/Popover.tsx
@@ -47,6 +47,7 @@ export type TFullPopoverProps = {
 	onMouseDown?: MouseEventHandler<Element>;
 	placement: PopoverPlacement;
 	align: PopoverAlign;
+	container?: Element;
 	onRequestClose?: () => any;
 	hasArrow?: boolean;
 	theme: {
@@ -89,7 +90,8 @@ class RawPopover extends React.Component<TFullPopoverProps, TPopoverState> {
 		super(props);
 
 		this.rootElement = document.createElement('div');
-		document.body.appendChild(this.rootElement);
+		const container = props.container || document.body;
+		container.appendChild(this.rootElement);
 	}
 
 	componentDidMount() {
@@ -103,7 +105,8 @@ class RawPopover extends React.Component<TFullPopoverProps, TPopoverState> {
 	}
 
 	componentWillUnmount() {
-		document.body.removeChild(this.rootElement);
+		const container = this.props.container || document.body;
+		container.removeChild(this.rootElement);
 	}
 
 	componentWillReceiveProps(nextProps: TFullPopoverProps) {

--- a/packages/react-kit/src/components/Popup/Popup.tsx
+++ b/packages/react-kit/src/components/Popup/Popup.tsx
@@ -29,6 +29,8 @@ export type TRawPopupProps = {
 
 	shouldCloseOnClickAway?: boolean;
 	onRequestClose?: () => any;
+
+	container?: Element;
 };
 
 @PURE
@@ -41,11 +43,13 @@ class RawPopup extends Component<TRawPopupProps> {
 		super(props);
 
 		this.rootElement = document.createElement('div');
-		document.body.appendChild(this.rootElement);
+		const container = props.container || document.body;
+		container.appendChild(this.rootElement);
 	}
 
 	componentWillUnmount() {
-		document.body.removeChild(this.rootElement);
+		const container = this.props.container || document.body;
+		container.removeChild(this.rootElement);
 	}
 
 	render() {

--- a/packages/react-kit/src/components/Scrollbar/Scrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/Scrollbar.tsx
@@ -5,6 +5,7 @@ import { Bar } from './Bar';
 
 import { CONTEXT_TYPES, EVENT_SCROLABLE, SCROLLABLE_CONTEXT_EMITTER } from '../Scrollable/Scrollable.const';
 
+export const SCROLLBAR = Symbol('Scrollbar') as symbol;
 export enum SCROLLBAR_TYPE {
 	HORIZONTAL = 'HORIZONTAL',
 	VERTICAL = 'VERTICAL',


### PR DESCRIPTION
`container` prop in Popup and Popover components was accidentally removed during upgrade to TS 2.8.
Same for Symbol in Scrollable