### PR TITLE
Update TypeScript to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@devexperts/platform",
   "scripts": {
-    "lerna": "lerna",
-    "lerna:bootstrap": "npm run lerna -- bootstrap",
-    "lerna:update": "npm run lerna -- clean && npm run lerna -- bootstrap",
-    "lerna:publish": "npm run lerna -- publish --conventional-commits",
     "start": "lerna run --parallel watch",
-    "start:storybook": "cd packages/react-kit && npm run start",
-    "build:kit": "cd packages/react-kit && npm run build",
-    "build:tools": "cd packages/tools && npm run build",
-    "build": "npm run build:tools && npm run build:kit",
-    "test": "npm run tslint && npm run jest",
+    "start:storybook": "cd packages/react-kit && yarn start",
+    "test": "yarn tslint && yarn jest",
+    "lerna": "lerna",
+    "lerna:bootstrap": "yarn lerna -- bootstrap",
+    "lerna:update": "yarn lerna -- clean && yarn lerna -- bootstrap",
+    "lerna:prepare": "yarn lerna run prepare",
+    "lerna:publish": "yarn lerna -- publish --conventional-commits",
+    "build:kit": "cd packages/react-kit && yarn build",
+    "build:tools": "cd packages/tools && yarn build",
+    "build": "yarn build:tools && yarn build:kit",
     "jest": "jest",
     "prettier": "prettier --list-different \"./packages/**/src/**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"./packages/**/src/**/*.{ts,tsx}\"",
@@ -60,6 +61,6 @@
     "prettier": "1.12.1",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.4"
+    "typescript": "^3.0.1"
   }
 }

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -32,11 +32,11 @@
   },
   "peerDependencies": {
     "tslint": "^5.10.0",
-    "typescript": "^2.8.4"
+    "typescript": "^3.0.1"
   },
   "devDependencies": {
     "@devexperts/tools": "^0.14.1",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.4"
+    "typescript": "^3.0.1"
   }
 }

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -38,7 +38,7 @@
     "react-css-themr": "^2.1.2",
     "rxjs": "~5.5.2",
     "tslib": "^1.9.0",
-    "typelevel-ts": "^0.2.2"
+    "typelevel-ts": "^0.3.1"
   },
   "peerDependencies": {
     "@types/react": ">=16.3.16",

--- a/packages/react-kit/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/react-kit/src/components/Autocomplete/Autocomplete.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { withTheme } from '../../utils/withTheme';
 import { ComponentClass, SFC } from 'react';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
-import { ObjectClean } from 'typelevel-ts';
 import { Menu, TMenuProps } from '../Menu/Menu';
 import { Input, TInputProps } from '../input/Input';
 import { Popover, TPopoverProps } from '../Popover/Popover';
@@ -124,8 +123,9 @@ class RawAutocomplete extends React.Component<TFullAutocompleteProps> {
 	};
 }
 
-export type TAutocompleteProps = ObjectClean<
-	PartialKeys<TFullAutocompleteProps, 'theme' | 'Input' | 'Popover' | 'MenuItem' | 'Menu'>
+export type TAutocompleteProps = PartialKeys<
+	TFullAutocompleteProps,
+	'theme' | 'Input' | 'Popover' | 'MenuItem' | 'Menu'
 >;
 export const Autocomplete: ComponentClass<TAutocompleteProps> = withTheme(AUTOCOMPLETE)(
 	withDefaults<TFullAutocompleteProps, 'Input' | 'Popover' | 'MenuItem' | 'Menu'>({

--- a/packages/react-kit/src/components/Autocomplete/AutocompleteMenuItem.tsx
+++ b/packages/react-kit/src/components/Autocomplete/AutocompleteMenuItem.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
-import { ObjectClean } from 'typelevel-ts';
 import { ComponentClass } from 'react';
 import { withTheme } from '../../utils/withTheme';
 import { MenuItem, TMenuItemProps } from '../Menu/Menu';
@@ -30,7 +29,7 @@ class RawAutocompleteMenuItem extends React.Component<TFullAutocompleteMenuItemP
 	}
 }
 
-export type TAutocompleteMenuItemProps = ObjectClean<PartialKeys<TFullAutocompleteMenuItemProps, 'theme' | 'search'>>;
+export type TAutocompleteMenuItemProps = PartialKeys<TFullAutocompleteMenuItemProps, 'theme' | 'search'>;
 export const AutocompleteMenuItem: ComponentClass<TAutocompleteMenuItemProps> = withTheme(AUTOCOMPLETE_MENU_ITEM)(
 	withDefaults<TFullAutocompleteMenuItemProps, 'search'>({
 		search: '',

--- a/packages/react-kit/src/components/Button/Button.tsx
+++ b/packages/react-kit/src/components/Button/Button.tsx
@@ -5,7 +5,6 @@ import { LoadingIndicator, TLoadingIndicatorProps } from '../LoadingIndicator/Lo
 import { withTheme } from '../../utils/withTheme';
 import { ComponentClass, EventHandler, MouseEvent } from 'react';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
-import { ObjectClean } from 'typelevel-ts';
 
 export const BUTTON = Symbol('Button') as symbol;
 
@@ -82,5 +81,5 @@ class RawButton extends React.Component<TFullButtonProps> {
 	}
 }
 
-export type TButtonProps = ObjectClean<PartialKeys<TFullButtonProps, 'theme'>>;
+export type TButtonProps = PartialKeys<TFullButtonProps, 'theme'>;
 export const Button: ComponentClass<TButtonProps> = withTheme(BUTTON)(RawButton);

--- a/packages/react-kit/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/react-kit/src/components/ButtonIcon/ButtonIcon.tsx
@@ -3,21 +3,18 @@ import { Button, TButtonProps } from '../Button/Button';
 import { PURE } from '../../utils/pure';
 import { ComponentClass, ComponentType } from 'react';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withDefaults } from '../../utils/with-defaults';
 
 export const BUTTON_ICON = Symbol('ButtonIcon') as symbol;
 
-export type TFullButtonIconProps = ObjectClean<
-	TButtonProps & {
-		Button: ComponentType<TButtonProps>;
-		icon: React.ReactNode;
-		theme: {
-			icon?: string;
-		} & TButtonProps['theme'];
-	}
->;
+export type TFullButtonIconProps = TButtonProps & {
+	Button: ComponentType<TButtonProps>;
+	icon: React.ReactNode;
+	theme: {
+		icon?: string;
+	} & TButtonProps['theme'];
+};
 
 @PURE
 class RawButtonIcon extends React.Component<TFullButtonIconProps> {
@@ -33,7 +30,7 @@ class RawButtonIcon extends React.Component<TFullButtonIconProps> {
 	}
 }
 
-export type TButtonIconProps = ObjectClean<PartialKeys<TFullButtonIconProps, 'Button' | 'theme'>>;
+export type TButtonIconProps = PartialKeys<TFullButtonIconProps, 'Button' | 'theme'>;
 export const ButtonIcon: ComponentClass<TButtonIconProps> = withTheme(BUTTON_ICON)(
 	withDefaults<TFullButtonIconProps, 'Button'>({
 		Button,

--- a/packages/react-kit/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-kit/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,6 @@ import { PURE } from '../../utils/pure';
 import * as classnames from 'classnames';
 
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 
@@ -61,5 +60,5 @@ class RawCheckbox extends Component<TFullCheckboxProps> {
 	};
 }
 
-export type TCheckboxProps = ObjectClean<PartialKeys<TFullCheckboxProps, 'theme'>>;
+export type TCheckboxProps = PartialKeys<TFullCheckboxProps, 'theme'>;
 export const Checkbox: ComponentClass<TCheckboxProps> = withTheme(CHECKBOX)(RawCheckbox);

--- a/packages/react-kit/src/components/Control/Control.ts
+++ b/packages/react-kit/src/components/Control/Control.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Requireable, ComponentClass } from 'react';
 import * as PropTypes from 'prop-types';
-import { ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 import SFC = React.SFC;
 
 export function createControlProps<TValue>(valueType: Requireable<TValue>) {
@@ -94,7 +94,7 @@ export type TStatefulProps<
 	N extends string = 'value',
 	D extends string = 'defaultValue',
 	H extends string = 'onValueChange'
-> = ObjectOmit<P, 'value' | N | H> & //remove both value name and handler name from props
+> = Omit<P, 'value' | N | H> & //remove both value name and handler name from props
 	Partial<TDynamicValueHandler<V, H>> & //add optional change handler to props
 	Partial<TDynamicValue<V, D>>; //add default value name to props - pass D (defaultValue name) here instead of N (value name)
 
@@ -124,7 +124,7 @@ export function stateful<
 
 			componentWillMount() {
 				this.setState({
-					value: this.props[defaultValueName as string],
+					value: this.props[defaultValueName] as any,
 				});
 			}
 
@@ -137,11 +137,11 @@ export function stateful<
 				return React.createElement(Target as any, props);
 			}
 
-			protected onValueChange = (value?: V): void => {
+			protected onValueChange = (value: V): void => {
 				this.setState({
 					value,
 				});
-				const onValueChange = this.props[handlerName as string];
+				const onValueChange: (value: V) => void = this.props[handlerName] as any;
 				onValueChange && onValueChange(value);
 			};
 		}

--- a/packages/react-kit/src/components/DateInput/DateInput.tsx
+++ b/packages/react-kit/src/components/DateInput/DateInput.tsx
@@ -10,7 +10,6 @@ import { ButtonIcon, TButtonIconProps } from '../ButtonIcon/ButtonIcon';
 import * as is_before from 'date-fns/is_before';
 import * as is_after from 'date-fns/is_after';
 import ReactInstance = React.ReactInstance;
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { PURE } from '../../utils/pure';
 import { Popover, TPopoverProps } from '../Popover/Popover';
@@ -549,13 +548,13 @@ class RawDateInput extends React.Component<TDateInputFullProps, TDateInputState>
 		this.secondInput = false;
 		if (!isDefined(this.state.activeSection)) {
 			this.setState({
-				activeSection: this.getDefaultActiveSection(),
+				activeSection: this.getDefaultActiveSection(this.props.dateFormatType),
 			});
 		}
 	};
 
-	private getDefaultActiveSection(): ActiveSection {
-		switch (this.props.dateFormatType) {
+	private getDefaultActiveSection(dateFormatType: DateFormatType): ActiveSection {
+		switch (dateFormatType) {
 			case DateFormatType.DMY: {
 				return ActiveSection.Day;
 			}
@@ -718,8 +717,9 @@ class RawDateInput extends React.Component<TDateInputFullProps, TDateInputState>
 	}
 }
 
-export type TDateInputProps = ObjectClean<
-	PartialKeys<TDateInputFullProps, 'theme' | 'SteppableInput' | 'ButtonIcon' | 'dateFormatType' | 'Popover'>
+export type TDateInputProps = PartialKeys<
+	TDateInputFullProps,
+	'theme' | 'SteppableInput' | 'ButtonIcon' | 'dateFormatType' | 'Popover'
 >;
 export const DateInput: ComponentClass<TDateInputProps> = withTheme(DATE_INPUT)(
 	withDefaults<TDateInputFullProps, 'SteppableInput' | 'ButtonIcon' | 'dateFormatType' | 'Popover'>({

--- a/packages/react-kit/src/components/Deferred/Deferred.tsx
+++ b/packages/react-kit/src/components/Deferred/Deferred.tsx
@@ -1,5 +1,4 @@
 import { ComponentClass, PureComponent, ReactElement } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withDefaults } from '../../utils/with-defaults';
 
@@ -49,7 +48,7 @@ class RawDeferred extends PureComponent<TRawDeferredProps, TDeferredState> {
 	}
 }
 
-export type TDeferredProps = ObjectClean<PartialKeys<TRawDeferredProps, 'delay'>>;
+export type TDeferredProps = PartialKeys<TRawDeferredProps, 'delay'>;
 export const Deferred: ComponentClass<TDeferredProps> = withDefaults<TRawDeferredProps, 'delay'>({
 	delay: 0,
 })(RawDeferred) as any;

--- a/packages/react-kit/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-kit/src/components/Dropdown/Dropdown.tsx
@@ -4,7 +4,6 @@ import { Component, ComponentClass, ComponentType, MouseEventHandler, ReactNode 
 import { Popover, TPopoverProps } from '../Popover/Popover';
 import { ReactRef, WithInnerRef } from '../../utils/typings';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 import { withDefaults } from '../../utils/with-defaults';
@@ -60,7 +59,7 @@ class RawDropdown extends Component<TFullDropdownProps> {
 	};
 }
 
-export type TDropdownProps = ObjectClean<PartialKeys<TFullDropdownProps, 'theme' | 'Popover'>>;
+export type TDropdownProps = PartialKeys<TFullDropdownProps, 'theme' | 'Popover'>;
 export const Dropdown: ComponentClass<TDropdownProps> = withTheme(DROPDOWN)(
 	withDefaults<TFullDropdownProps, 'Popover'>({
 		Popover,

--- a/packages/react-kit/src/components/Expandable/Expandable.tsx
+++ b/packages/react-kit/src/components/Expandable/Expandable.tsx
@@ -4,7 +4,6 @@ import { ExpandableHandler, TExpandableHandlerProps } from './ExpandableHandler'
 import { PURE } from '../../utils/pure';
 import { ComponentClass } from 'react';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 import { withDefaults } from '../../utils/with-defaults';
@@ -47,7 +46,7 @@ class RawExpandable extends React.Component<TFullExpandableProps> {
 	};
 }
 
-export type TExpandableProps = ObjectClean<PartialKeys<TFullExpandableProps, 'theme' | 'Handler'>>;
+export type TExpandableProps = PartialKeys<TFullExpandableProps, 'theme' | 'Handler'>;
 export const Expandable: ComponentClass<TExpandableProps> = withTheme(EXPANDABLE)(
 	withDefaults<TFullExpandableProps, 'Handler'>({
 		Handler: ExpandableHandler,

--- a/packages/react-kit/src/components/Expandable/ExpandableHandler.tsx
+++ b/packages/react-kit/src/components/Expandable/ExpandableHandler.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import { ComponentClass, ReactElement } from 'react';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 export const EXPANDABLE_HEADER = Symbol() as symbol;
@@ -23,7 +22,7 @@ class RawExpandableHandler extends React.Component<TFullExpandableHandlerProps> 
 	}
 }
 
-export type TExpandableHandlerProps = ObjectClean<PartialKeys<TFullExpandableHandlerProps, 'theme' | 'isExpanded'>>;
+export type TExpandableHandlerProps = PartialKeys<TFullExpandableHandlerProps, 'theme' | 'isExpanded'>;
 export const ExpandableHandler: ComponentClass<TExpandableHandlerProps> = withTheme(EXPANDABLE_HEADER)(
 	RawExpandableHandler,
 );

--- a/packages/react-kit/src/components/Grid/Grid.tsx
+++ b/packages/react-kit/src/components/Grid/Grid.tsx
@@ -24,7 +24,7 @@ import {
 import Emitter from '@devexperts/utils/dist/emitter/Emitter';
 import { Scrollable } from '../Scrollable/Scrollable';
 import * as classnames from 'classnames';
-import { ObjectClean, ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
@@ -50,7 +50,7 @@ const CONTEXT_TYPES = {
 	[GRID_CONTEXT_EMITTER]: PropTypes.instanceOf(GridInternalEmitter).isRequired,
 };
 
-export type TFullGridProps = ObjectOmit<TFullTableProps, 'theme'> & {
+export type TFullGridProps = Omit<TFullTableProps, 'theme'> & {
 	theme: TTableTheme & {
 		gridHead?: string;
 		gridHead_paddedForScrollbar?: string;
@@ -472,17 +472,17 @@ class RawGridCell extends React.Component<TFullGridCellProps> {
 	}
 }
 
-export type TGridProps = ObjectClean<PartialKeys<TFullGridProps, 'theme'>>;
+export type TGridProps = PartialKeys<TFullGridProps, 'theme'>;
 export const Grid: React.ComponentClass<TGridProps> = withTheme(GRID)(RawGrid);
 
-export type TGridBodyProps = ObjectClean<PartialKeys<TFullGridBodyProps, 'theme'>>;
+export type TGridBodyProps = PartialKeys<TFullGridBodyProps, 'theme'>;
 export const GridBody: React.ComponentClass<TGridBodyProps> = withTheme(GRID)(RawGridBody);
 
-export type TGridHeadProps = ObjectClean<PartialKeys<TFullGridHeadProps, 'theme'>>;
+export type TGridHeadProps = PartialKeys<TFullGridHeadProps, 'theme'>;
 export const GridHead: React.ComponentClass<TGridHeadProps> = withTheme(GRID)(RawGridHead);
 
-export type TGridRowProps = ObjectClean<PartialKeys<TFullGridRowProps, 'theme'>>;
+export type TGridRowProps = PartialKeys<TFullGridRowProps, 'theme'>;
 export const GridRow: React.ComponentClass<TGridRowProps> = withTheme(GRID)(RawGridRow);
 
-export type TGridCellProps = ObjectClean<PartialKeys<TFullGridCellProps, 'theme'>>;
+export type TGridCellProps = PartialKeys<TFullGridCellProps, 'theme'>;
 export const GridCell: React.ComponentClass<TGridCellProps> = withTheme(GRID)(RawGridCell);

--- a/packages/react-kit/src/components/Highlight/Highlight.tsx
+++ b/packages/react-kit/src/components/Highlight/Highlight.tsx
@@ -3,7 +3,6 @@ import split from '@devexperts/utils/dist/string/split';
 import { PURE } from '../../utils/pure';
 import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
-import { ObjectClean } from 'typelevel-ts/lib';
 import { ComponentClass, ReactNode } from 'react';
 import { withDefaults } from '../../utils/with-defaults';
 
@@ -48,7 +47,7 @@ class RawHighlight extends React.Component<TFullHighlightProps> {
 	}
 }
 
-export type THighlightProps = ObjectClean<PartialKeys<TFullHighlightProps, 'theme' | 'search'>>;
+export type THighlightProps = PartialKeys<TFullHighlightProps, 'theme' | 'search'>;
 export const Highlight: ComponentClass<THighlightProps> = withTheme(HIGHLIGHT)(
 	withDefaults<TFullHighlightProps, 'search'>({
 		search: '',

--- a/packages/react-kit/src/components/Holdable/Holdable.tsx
+++ b/packages/react-kit/src/components/Holdable/Holdable.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { ReactElement, EventHandler, MouseEvent, TouchEvent } from 'react';
-import { ObjectClean } from 'typelevel-ts/lib';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withDefaults } from '../../utils/with-defaults';
 
@@ -85,7 +84,7 @@ class RawHoldable extends React.Component<TFullHoldableProps> {
 	};
 }
 
-export type THoldableProps = ObjectClean<PartialKeys<TFullHoldableProps, 'delay' | 'interval'>>;
+export type THoldableProps = PartialKeys<TFullHoldableProps, 'delay' | 'interval'>;
 export const Holdable = withDefaults<TFullHoldableProps, 'delay' | 'interval'>({
 	interval: 50,
 	delay: 300,

--- a/packages/react-kit/src/components/Link/Link.tsx
+++ b/packages/react-kit/src/components/Link/Link.tsx
@@ -4,7 +4,6 @@ import * as classnames from 'classnames';
 import { MouseEvent, EventHandler, ComponentClass } from 'react';
 import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
-import { ObjectClean } from 'typelevel-ts/lib';
 
 export const LINK = Symbol('Link') as symbol;
 
@@ -47,5 +46,5 @@ class RawLink extends React.Component<TFullLinkProps> {
 	};
 }
 
-export type TLinkProps = ObjectClean<PartialKeys<TFullLinkProps, 'theme'>>;
+export type TLinkProps = PartialKeys<TFullLinkProps, 'theme'>;
 export const Link: ComponentClass<TLinkProps> = withTheme(LINK)(RawLink);

--- a/packages/react-kit/src/components/List/List.tsx
+++ b/packages/react-kit/src/components/List/List.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as classnames from 'classnames';
 import { withTheme } from '../../utils/withTheme';
 import { ComponentClass, MouseEventHandler, ReactNode } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { PURE } from '../../utils/pure';
 
@@ -32,7 +31,7 @@ class RawList extends React.Component<TFullListProps> {
 	}
 }
 
-export type TListProps = ObjectClean<PartialKeys<TFullListProps, 'theme'>>;
+export type TListProps = PartialKeys<TFullListProps, 'theme'>;
 export const List: ComponentClass<TListProps> = withTheme(LIST)(RawList);
 
 export type TFullListItemProps = {
@@ -61,7 +60,7 @@ class RawListItem extends React.Component<TFullListItemProps> {
 	}
 }
 
-export type TListItemProps = ObjectClean<PartialKeys<TFullListItemProps, 'theme'>>;
+export type TListItemProps = PartialKeys<TFullListItemProps, 'theme'>;
 export const ListItem: ComponentClass<TListItemProps> = withTheme(LIST)(RawListItem);
 
 export type TFullListItemGroupProps = {
@@ -109,5 +108,5 @@ class RawListItemGroup extends React.Component<TFullListItemGroupProps> {
 	}
 }
 
-export type TListItemGroupProps = ObjectClean<PartialKeys<TFullListItemGroupProps, 'theme'>>;
+export type TListItemGroupProps = PartialKeys<TFullListItemGroupProps, 'theme'>;
 export const ListItemGroup: ComponentClass<TListItemGroupProps> = withTheme(LIST)(RawListItemGroup);

--- a/packages/react-kit/src/components/LoadingIndication/LoadingIndication.tsx
+++ b/packages/react-kit/src/components/LoadingIndication/LoadingIndication.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass, ComponentType } from 'react';
 
@@ -38,7 +37,7 @@ class RawLoadingIndicaton extends React.Component<TRawLoadingIndicatonProps> {
 	}
 }
 
-export type TLoadingIndicationProps = ObjectClean<PartialKeys<TRawLoadingIndicatonProps, 'LoadingIndicator' | 'theme'>>;
+export type TLoadingIndicationProps = PartialKeys<TRawLoadingIndicatonProps, 'LoadingIndicator' | 'theme'>;
 export const LoadingIndication: ComponentClass<TLoadingIndicationProps> = withTheme(LOADING_INDICATION)(
 	withDefaults<TRawLoadingIndicatonProps, 'LoadingIndicator'>({
 		LoadingIndicator,

--- a/packages/react-kit/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/packages/react-kit/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass } from 'react';
 
@@ -22,7 +21,7 @@ class RawLoadingIndicator extends React.Component<TFullLoadingIndicatorProps> {
 	}
 }
 
-export type TLoadingIndicatorProps = ObjectClean<PartialKeys<TFullLoadingIndicatorProps, 'theme'>>;
+export type TLoadingIndicatorProps = PartialKeys<TFullLoadingIndicatorProps, 'theme'>;
 export const LoadingIndicator: ComponentClass<TLoadingIndicatorProps> = withTheme(LOADING_INDICATOR)(
 	RawLoadingIndicator,
 );

--- a/packages/react-kit/src/components/Menu/Menu.tsx
+++ b/packages/react-kit/src/components/Menu/Menu.tsx
@@ -12,7 +12,6 @@ import {
 } from '../List/List';
 import { withTheme } from '../../utils/withTheme';
 import { Component, ComponentClass, ComponentType, ReactElement, ReactNode, ReactText } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { PURE } from '../../utils/pure';
 import * as classnames from 'classnames';
@@ -162,8 +161,9 @@ class RawMenuItemGroup extends React.Component<TFullMenuItemGroupProps, TMenuIte
 	};
 }
 
-export type TMenuItemGroupProps = ObjectClean<
-	PartialKeys<TFullMenuItemGroupProps, 'theme' | 'List' | 'ListItemGroup' | 'isCollapsed'>
+export type TMenuItemGroupProps = PartialKeys<
+	TFullMenuItemGroupProps,
+	'theme' | 'List' | 'ListItemGroup' | 'isCollapsed'
 >;
 export const MenuItemGroup: ComponentClass<TMenuItemGroupProps> = withTheme(MENU)(
 	withDefaults<TFullMenuItemGroupProps, 'ListItemGroup' | 'isCollapsed' | 'List'>({

--- a/packages/react-kit/src/components/NumericStepper/NumericStepper.tsx
+++ b/packages/react-kit/src/components/NumericStepper/NumericStepper.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { SteppableInput, TSteppableInputProps } from '../SteppableInput/SteppableInput';
 import { KeyCode, TControlProps } from '../Control/Control';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentClass } from 'react';
 import { Input, TInputProps } from '../input/Input';
@@ -254,8 +253,9 @@ class RawNumericStepper extends React.Component<TNumericStepperFullProps, TNumer
 	};
 }
 
-export type TNumericStepperProps = ObjectClean<
-	PartialKeys<TNumericStepperFullProps, 'theme' | 'SteppableInput' | 'step' | 'max' | 'min' | 'manualEdit'>
+export type TNumericStepperProps = PartialKeys<
+	TNumericStepperFullProps,
+	'theme' | 'SteppableInput' | 'step' | 'max' | 'min' | 'manualEdit'
 >;
 export const NumericStepper: ComponentClass<TNumericStepperProps> = withTheme(NUMERIC_STEPPER)(
 	withDefaults<TNumericStepperFullProps, 'SteppableInput' | 'step' | 'max' | 'min' | 'manualEdit'>({

--- a/packages/react-kit/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/react-kit/src/components/PasswordInput/PasswordInput.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import { ButtonIcon, TButtonIconProps } from '../ButtonIcon/ButtonIcon';
 import { Input as BaseInput, TInputProps } from '../input/Input';
-import { ObjectClean } from 'typelevel-ts';
 import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ComponentType } from 'react';
@@ -64,5 +63,5 @@ export class RawPasswordInput extends React.Component<TFullPasswordInputProps> {
 	};
 }
 
-export type TPasswordInputProps = ObjectClean<PartialKeys<TFullPasswordInputProps, 'theme'>>;
+export type TPasswordInputProps = PartialKeys<TFullPasswordInputProps, 'theme'>;
 export const PasswordInput: React.ComponentClass<TPasswordInputProps> = withTheme(PASSWORD_INPUT)(RawPasswordInput);

--- a/packages/react-kit/src/components/Popover/Popover.tsx
+++ b/packages/react-kit/src/components/Popover/Popover.tsx
@@ -9,7 +9,6 @@ import throttle from '@devexperts/utils/dist/function/throttle';
 
 import { withTheme } from '../../utils/withTheme';
 import { ComponentClass, MouseEventHandler, ReactNode, SyntheticEvent } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ReactRef } from '../../utils/typings';
 import { EventListener } from '../EventListener/EventListener';
@@ -304,7 +303,7 @@ class RawPopover extends React.Component<TFullPopoverProps, TPopoverState> {
 	}
 }
 
-export type TPopoverProps = ObjectClean<PartialKeys<TFullPopoverProps, 'theme' | 'align' | 'placement'>>;
+export type TPopoverProps = PartialKeys<TFullPopoverProps, 'theme' | 'align' | 'placement'>;
 export const Popover: ComponentClass<TPopoverProps> = withTheme(POPOVER)(
 	withDefaults<TFullPopoverProps, 'align' | 'placement'>({
 		align: PopoverAlign.Left,

--- a/packages/react-kit/src/components/Popup/Popup.tsx
+++ b/packages/react-kit/src/components/Popup/Popup.tsx
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom';
 import { PURE } from '../../utils/pure';
 import * as classnames from 'classnames';
 import { Component, MouseEventHandler, ReactNode } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 import { RootClose } from '../RootClose/RootClose';
@@ -108,5 +107,5 @@ class RawPopup extends Component<TRawPopupProps> {
 	};
 }
 
-export type TPopupProps = ObjectClean<PartialKeys<TRawPopupProps, 'theme'>>;
+export type TPopupProps = PartialKeys<TRawPopupProps, 'theme'>;
 export const Popup = withTheme(POPUP)(RawPopup);

--- a/packages/react-kit/src/components/ResizeDetector/ResizeDetector.tsx
+++ b/packages/react-kit/src/components/ResizeDetector/ResizeDetector.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import { withTheme } from '../../utils/withTheme';
 import { ComponentClass } from 'react';
-import { ObjectClean } from 'typelevel-ts/lib';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 import * as detectorFactory from 'element-resize-detector';
@@ -47,5 +46,5 @@ class RawResizeDetector extends React.Component<TFullResizeDetectorProps> {
 	});
 }
 
-export type TResizeDetectorProps = ObjectClean<PartialKeys<TFullResizeDetectorProps, 'theme'>>;
+export type TResizeDetectorProps = PartialKeys<TFullResizeDetectorProps, 'theme'>;
 export const ResizeDetector: ComponentClass<TResizeDetectorProps> = withTheme(RESIZE_DETECTOR)(RawResizeDetector);

--- a/packages/react-kit/src/components/Scrollable/Scrollable.tsx
+++ b/packages/react-kit/src/components/Scrollable/Scrollable.tsx
@@ -18,7 +18,6 @@ import { VerticalScrollbar as BaseVerticalScrollbar, TVerticalScrollbarProps } f
 
 import getScrollbarSize from '../Scrollbar/Scrollbar.util';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withDefaults } from '../../utils/with-defaults';
 
@@ -182,8 +181,9 @@ export class RawScrollable extends React.Component<TFullScrollableProps> {
 	};
 }
 
-export type TScrollableProps = ObjectClean<
-	PartialKeys<TFullScrollableProps, 'theme' | 'ResizeDetector' | 'VerticalScrollbar' | 'HorizontalScrollbar'>
+export type TScrollableProps = PartialKeys<
+	TFullScrollableProps,
+	'theme' | 'ResizeDetector' | 'VerticalScrollbar' | 'HorizontalScrollbar'
 >;
 export const Scrollable: React.ComponentClass<TScrollableProps> = withTheme(SCROLLABLE)(
 	withDefaults<TFullScrollableProps, 'ResizeDetector' | 'VerticalScrollbar' | 'HorizontalScrollbar'>({

--- a/packages/react-kit/src/components/Scrollbar/Bar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/Bar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import { EventListener, TEventListenerProps } from '../EventListener/EventListener';
-import { ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 
 export type TBarProps = {
 	onBarDragStart: React.MouseEventHandler<HTMLDivElement>;
@@ -24,7 +24,7 @@ export class Bar extends React.Component<TBarProps, TBarState> {
 	render() {
 		const { isDragging } = this.state;
 
-		let eventListenerProps: ObjectOmit<TEventListenerProps, 'children'> = {
+		let eventListenerProps: Omit<TEventListenerProps, 'children'> = {
 			target: 'window',
 			capture: true,
 		};

--- a/packages/react-kit/src/components/Scrollbar/HorizontalScrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/HorizontalScrollbar.tsx
@@ -4,7 +4,6 @@ import { Scrollbar, SCROLLBAR_TYPE, TScrollbarProps } from './Scrollbar';
 import { EVENT_SCROLABLE, SCROLLABLE_CONTEXT_EMITTER } from '../Scrollable/Scrollable.const';
 
 import { PURE } from '../../utils/pure';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
@@ -174,7 +173,7 @@ export class RawHorizontalScrollbar extends Scrollbar<TAdditionalHorizontalProps
 	};
 }
 
-export type THorizontalScrollbarProps = ObjectClean<PartialKeys<TFullHorizontalProps, 'theme'>>;
+export type THorizontalScrollbarProps = PartialKeys<TFullHorizontalProps, 'theme'>;
 export const HorizontalScrollbar: React.ComponentClass<THorizontalScrollbarProps> = withTheme(HORIZONTAL_SCROLLBAR)(
 	RawHorizontalScrollbar,
 );

--- a/packages/react-kit/src/components/Scrollbar/VerticalScrollbar.tsx
+++ b/packages/react-kit/src/components/Scrollbar/VerticalScrollbar.tsx
@@ -3,7 +3,6 @@ import { Scrollbar, SCROLLBAR_TYPE, TScrollbarProps } from './Scrollbar';
 import { EVENT_SCROLABLE, SCROLLABLE_CONTEXT_EMITTER } from '../Scrollable/Scrollable.const';
 import { PURE } from '../../utils/pure';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 export const VERTICAL_SCROLLBAR = Symbol('VerticalScrollbar') as symbol;
@@ -174,7 +173,7 @@ export class RawVerticalScrollbar extends Scrollbar<TAdditionalVerticalScrollBar
 	};
 }
 
-export type TVerticalScrollbarProps = ObjectClean<PartialKeys<TFullVerticalScrollBarProp, 'theme'>>;
+export type TVerticalScrollbarProps = PartialKeys<TFullVerticalScrollBarProp, 'theme'>;
 export const VerticalScrollbar: React.ComponentClass<TVerticalScrollbarProps> = withTheme(VERTICAL_SCROLLBAR)(
 	RawVerticalScrollbar,
 );

--- a/packages/react-kit/src/components/Selectbox/Selectbox.page.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.page.tsx
@@ -12,7 +12,6 @@ import { SmallDropDownArrowIcon } from '../../icons/small-dropdown-arrow-icon';
 import { stateful } from '../Control/Control';
 
 import * as selectoxPageCss from './Selectbox.page.styl';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 const wideSelectboxTheme = {
 	container__anchor: selectoxPageCss.container__anchor,
@@ -28,9 +27,7 @@ class DemoSelectboxAnchor extends React.Component<TFullSelectboxAnchorProps> {
 	}
 }
 
-class DemoSelectbox extends React.Component<
-	ObjectClean<PartialKeys<TFullSelectboxProps, 'theme' | 'Anchor' | 'Menu' | 'Popover'>>
-> {
+class DemoSelectbox extends React.Component<PartialKeys<TFullSelectboxProps, 'theme' | 'Anchor' | 'Menu' | 'Popover'>> {
 	render() {
 		const newProps = {
 			...this.props,

--- a/packages/react-kit/src/components/Selectbox/Selectbox.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.tsx
@@ -6,7 +6,6 @@ import { PURE } from '../../utils/pure';
 import * as classnames from 'classnames';
 import { withTheme } from '../../utils/withTheme';
 import { Component, ComponentClass, ComponentType, ReactElement, ReactNode, ReactText } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { TControlProps } from '../Control/Control';
 import { NativeResizeDetector } from '../ResizeDetector/ResizeDetector';
@@ -265,7 +264,7 @@ class RawSelectbox extends React.Component<TFullSelectboxProps, TSelectboxState>
 	});
 }
 
-export type TSelectboxProps = ObjectClean<PartialKeys<TFullSelectboxProps, 'theme' | 'Anchor' | 'Menu' | 'Popover'>>;
+export type TSelectboxProps = PartialKeys<TFullSelectboxProps, 'theme' | 'Anchor' | 'Menu' | 'Popover'>;
 export const Selectbox: ComponentClass<TSelectboxProps> = withTheme(SELECTBOX)(
 	withDefaults<TFullSelectboxProps, 'Anchor' | 'Menu' | 'Popover'>({
 		Anchor: SelectboxAnchor,

--- a/packages/react-kit/src/components/Selectbox/SelectboxAnchor.tsx
+++ b/packages/react-kit/src/components/Selectbox/SelectboxAnchor.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import { Button, TButtonProps, TFullButtonProps } from '../Button/Button';
 import { ComponentClass, ReactNode } from 'react';
-import { ObjectClean, ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import * as classnames from 'classnames';
 
-export type TFullSelectboxAnchorProps = ObjectOmit<TButtonProps, 'theme'> & {
+export type TFullSelectboxAnchorProps = Omit<TButtonProps, 'theme'> & {
 	theme: TFullButtonProps['theme'] & {
 		text?: string;
 		content?: string;
@@ -58,5 +58,5 @@ class RawSelectboxAnchor extends React.Component<TFullSelectboxAnchorProps> {
 	}
 }
 
-export type TSelectboxAnchorProps = ObjectClean<PartialKeys<TFullSelectboxAnchorProps, 'theme'>>;
+export type TSelectboxAnchorProps = PartialKeys<TFullSelectboxAnchorProps, 'theme'>;
 export const SelectboxAnchor: ComponentClass<TSelectboxAnchorProps> = RawSelectboxAnchor as any;

--- a/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
+++ b/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
@@ -3,7 +3,6 @@ import { PURE } from '../../utils/pure';
 import { ComponentClass } from 'react';
 import * as ReactDOM from 'react-dom';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { ButtonIcon, TButtonIconProps } from '../ButtonIcon/ButtonIcon';
 import { Input, TInputProps } from '../input/Input';
@@ -199,7 +198,7 @@ class RawSteppableInput extends React.Component<TFullSteppableInputProps, TStepp
 	};
 }
 
-export type TSteppableInputProps = ObjectClean<PartialKeys<TFullSteppableInputProps, 'theme' | 'Input' | 'ButtonIcon'>>;
+export type TSteppableInputProps = PartialKeys<TFullSteppableInputProps, 'theme' | 'Input' | 'ButtonIcon'>;
 export const SteppableInput: ComponentClass<TSteppableInputProps> = withTheme(STEPPABLE_INPUT)(
 	withDefaults<TFullSteppableInputProps, 'Input' | 'ButtonIcon'>({
 		Input,

--- a/packages/react-kit/src/components/Table/Table.tsx
+++ b/packages/react-kit/src/components/Table/Table.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { PURE } from '../../utils/pure';
 import * as classnames from 'classnames';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts/lib';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 export const TABLE = Symbol('Table') as symbol;
@@ -124,17 +123,17 @@ class RawTableCell extends React.Component<TFullTableCellProps> {
 	}
 }
 
-export type TTableProps = ObjectClean<PartialKeys<TFullTableProps, 'theme'>>;
+export type TTableProps = PartialKeys<TFullTableProps, 'theme'>;
 export const Table: React.ComponentClass<TTableProps> = withTheme(TABLE)(RawTable);
 
-export type TTableBodyProps = ObjectClean<PartialKeys<TFullTableBodyProps, 'theme'>>;
+export type TTableBodyProps = PartialKeys<TFullTableBodyProps, 'theme'>;
 export const TableBody: React.ComponentClass<TTableBodyProps> = withTheme(TABLE)(RawTableBody);
 
-export type TTableHeadProps = ObjectClean<PartialKeys<TFullTableHeadProps, 'theme'>>;
+export type TTableHeadProps = PartialKeys<TFullTableHeadProps, 'theme'>;
 export const TableHead: React.ComponentClass<TTableHeadProps> = withTheme(TABLE)(RawTableHead);
 
-export type TTableRowProps = ObjectClean<PartialKeys<TFullTableRowProps, 'theme'>>;
+export type TTableRowProps = PartialKeys<TFullTableRowProps, 'theme'>;
 export const TableRow: React.ComponentClass<TTableRowProps> = withTheme(TABLE)(RawTableRow);
 
-export type TTableCellProps = ObjectClean<PartialKeys<TFullTableCellProps, 'theme'>>;
+export type TTableCellProps = PartialKeys<TFullTableCellProps, 'theme'>;
 export const TableCell: React.ComponentClass<TTableCellProps> = withTheme(TABLE)(RawTableCell);

--- a/packages/react-kit/src/components/TimeInput/TimeInput.tsx
+++ b/packages/react-kit/src/components/TimeInput/TimeInput.tsx
@@ -4,7 +4,6 @@ import { ComponentClass } from 'react';
 import { TControlProps, KeyCode, KEY_CODE_NUM_MAP } from '../Control/Control';
 import * as classnames from 'classnames';
 import { withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { SteppableInput, TSteppableInputProps } from '../SteppableInput/SteppableInput';
 import { withDefaults } from '../../utils/with-defaults';
@@ -321,7 +320,7 @@ class RawTimeInput extends React.Component<TTimeInputFullProps, TTimeInputState>
 	}
 }
 
-export type TTimeInputProps = ObjectClean<PartialKeys<TTimeInputFullProps, 'theme' | 'SteppableInput'>>;
+export type TTimeInputProps = PartialKeys<TTimeInputFullProps, 'theme' | 'SteppableInput'>;
 export const TimeInput: ComponentClass<TTimeInputProps> = withTheme(TIME_INPUT)(
 	withDefaults<TTimeInputFullProps, 'SteppableInput'>({
 		SteppableInput,

--- a/packages/react-kit/src/components/ToggleButtons/ToggleButtons.tsx
+++ b/packages/react-kit/src/components/ToggleButtons/ToggleButtons.tsx
@@ -3,7 +3,6 @@ import { Component, ReactElement, ComponentClass, ReactText } from 'react';
 import { PURE } from '../../utils/pure';
 import * as classnames from 'classnames';
 import { mergeThemes, withTheme } from '../../utils/withTheme';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 export const TOGGLE_BUTTONS = Symbol('ToggleButtons') as symbol;
@@ -103,5 +102,5 @@ class RawToggleButtons extends Component<TFullToggleButtonsProps, TToggleButtons
 	};
 }
 
-export type TToggleButtonsProps = ObjectClean<PartialKeys<TFullToggleButtonsProps, 'theme'>>;
+export type TToggleButtonsProps = PartialKeys<TFullToggleButtonsProps, 'theme'>;
 export const ToggleButtons: ComponentClass<TToggleButtonsProps> = withTheme(TOGGLE_BUTTONS)(RawToggleButtons);

--- a/packages/react-kit/src/components/demo/Demo.tsx
+++ b/packages/react-kit/src/components/demo/Demo.tsx
@@ -5,7 +5,6 @@ import { DefaultTheme } from '../DefaultTheme/DefaultTheme';
 
 import * as css from './Demo.styl';
 
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 const DEMO = Symbol();
@@ -24,7 +23,7 @@ class RawDemoComponent extends React.Component<TFullDemoComponentProps> {
 	}
 }
 
-export type TDemoComponentProps = ObjectClean<PartialKeys<TFullDemoComponentProps, 'theme'>>;
+export type TDemoComponentProps = PartialKeys<TFullDemoComponentProps, 'theme'>;
 export const DemoComponent: React.ComponentClass<TDemoComponentProps> = withTheme(DEMO, css)(RawDemoComponent);
 
 const Demo: React.SFC<Partial<TFullDemoComponentProps>> = props => (

--- a/packages/react-kit/src/components/input/Input.tsx
+++ b/packages/react-kit/src/components/input/Input.tsx
@@ -11,7 +11,6 @@ import {
 	MouseEventHandler,
 	WheelEventHandler,
 } from 'react';
-import { ObjectClean } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 import { withTheme } from '../../utils/withTheme';
 
@@ -173,5 +172,5 @@ class RawInput extends React.Component<TFullInputProps, TInputState> {
 	};
 }
 
-export type TInputProps = ObjectClean<PartialKeys<TFullInputProps, 'theme'>>;
+export type TInputProps = PartialKeys<TFullInputProps, 'theme'>;
 export const Input: ComponentClass<TInputProps> = withTheme(INPUT)(RawInput);

--- a/packages/react-kit/src/utils/defaults.ts
+++ b/packages/react-kit/src/utils/defaults.ts
@@ -1,8 +1,8 @@
 import { ComponentType } from 'react';
-import { ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 
 export function defaults<K extends keyof D, D extends {}>(defaults: D) {
-	function decorate<P extends D>(Target: ComponentType<P & D>): ComponentType<ObjectOmit<P, K> & Partial<D>> {
+	function decorate<P extends D>(Target: ComponentType<P & D>): ComponentType<Omit<P, K> & Partial<D>> {
 		Target.defaultProps = defaults;
 		return Target as any;
 	}

--- a/packages/react-kit/src/utils/withTheme.ts
+++ b/packages/react-kit/src/utils/withTheme.ts
@@ -5,7 +5,7 @@ import * as React from 'react';
 //     ComponentType
 // } from 'react';
 import * as PropTypes from 'prop-types';
-import { ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
 
 const THEME_CONTEXT_KEY = '@@dx-util/withTheme-context-key'; //should be serializable
@@ -19,7 +19,7 @@ type TTargetProps = {
 	theme?: TTheme;
 };
 
-type TResultProps<P extends TTargetProps> = ObjectOmit<P, 'theme'> & {
+type TResultProps<P extends TTargetProps> = Omit<P, 'theme'> & {
 	theme?: P['theme'];
 };
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -89,7 +89,7 @@
     "sync-glob": "1.3.7",
     "ts-loader": "^3.2.0",
     "tslib": "^1.9.0",
-    "typescript": "2.8.1",
+    "typescript": "^3.0.1",
     "url-loader": "^0.6.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.10.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/devex-web-frontend/dx-platform#readme",
   "dependencies": {
     "tslib": "^1.9.0",
-    "typelevel-ts": "^0.2.2"
+    "typelevel-ts": "^0.3.1"
   },
   "peerDependencies": {
     "fp-ts": "^1.2.0"

--- a/packages/utils/src/object/object.ts
+++ b/packages/utils/src/object/object.ts
@@ -1,4 +1,4 @@
-import { ObjectOmit } from 'typelevel-ts';
+import { Omit } from 'typelevel-ts';
 
 import { is, hasOwnProperty } from './fb';
 
@@ -47,6 +47,6 @@ export function deepEqual(objA: object, objB: object): boolean {
 	return true;
 }
 
-export type PartialKeys<T extends {}, K extends keyof T> = ObjectOmit<T, K> & Partial<Pick<T, K>>;
+export type PartialKeys<T extends {}, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export const isNotNullable = <T>(value: T | null | undefined): value is T => value !== null && value !== undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8855,17 +8855,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typelevel-ts@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/typelevel-ts/-/typelevel-ts-0.2.4.tgz#d4832c6fb739abe0bc1c29b098e158fe0778f3f0"
+typelevel-ts@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/typelevel-ts/-/typelevel-ts-0.3.1.tgz#05aec16b3437d6b04a073c9036f9f5ae24ec359d"
 
-typescript@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
-
-typescript@^2.8.4:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
updated `typescript` to 3.0.1
updated `typelevel-ts` to 0.3.1
deleted `ObjectClean` usages, because this type was deleted from `typelevel-ts` and it does almost nothing (in usage cases)
had to make a lot of crutches with `any` in `stateful`