### PR TITLE
fix(react-kit): add focus on selectbox anchor after selecting value

### DIFF
--- a/packages/react-kit/src/components/Selectbox/Selectbox.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.tsx
@@ -249,6 +249,7 @@ class RawSelectbox extends React.Component<TFullSelectboxProps, TSelectboxState>
 			isOpened: false,
 		});
 		this.props.onValueChange && this.props.onValueChange(value);
+		this.focusOnAnchor();
 	};
 
 	onPopoverRequestClose = () => {
@@ -265,6 +266,16 @@ class RawSelectbox extends React.Component<TFullSelectboxProps, TSelectboxState>
 			});
 		}
 	});
+
+	private focusOnAnchor() {
+		if (!this.anchor) {
+			return;
+		}
+		const anchor = findDOMNode(this.anchor);
+		if (anchor instanceof HTMLElement) {
+			anchor.focus();
+		}
+	};
 }
 
 export type TSelectboxProps = ObjectClean<PartialKeys<TFullSelectboxProps, 'theme' | 'Anchor' | 'Menu' | 'Popover'>>;


### PR DESCRIPTION
Current behavior: after selecting value focus is lost (it moves to the start of the page, to be precise)
Introduced behavior: after selecting value focus moves to the Selectbox anchor