### PR TITLE
feat: add pending state to render remote data

### DIFF
--- a/packages/react-kit/src/components/render-remote-data/demo/render-remote-data.page.tsx
+++ b/packages/react-kit/src/components/render-remote-data/demo/render-remote-data.page.tsx
@@ -1,22 +1,35 @@
 import { storiesOf } from '@storybook/react';
 import { getRenderRemoteData } from '../get-render-remote-data';
 import * as React from 'react';
-import { SFC } from 'react';
-import { failure, success } from '@devexperts/remote-data-ts';
+import { Fragment, SFC } from 'react';
+import { failure, pending, success } from '@devexperts/remote-data-ts';
+import Demo from '../../demo/Demo';
 
-const DataStateError: SFC<{ error: Error }> = props => <div>error: {props.error.message}</div>;
-const DataStateNoDate = () => <div>no data</div>;
+const DataStatePending = () => <div>pending</div>;
+const DataStateFailure: SFC<{ error: Error }> = props => <div>error: {props.error.message}</div>;
+const DataStateNoData = () => <div>no data</div>;
 
 const RenderRemoteData = getRenderRemoteData({
-	DataStateNoData: DataStateNoDate,
-	DataStateFailure: DataStateError,
+	DataStatePending,
+	DataStateNoData,
+	DataStateFailure,
 });
 
 const renderSuccess = (data: string) => <div>{data}</div>;
 
-storiesOf('RenderRemoteData', module)
-	.add('success', () => <RenderRemoteData success={renderSuccess} data={success('success')} />)
-	.add('error', () => (
-		<RenderRemoteData success={renderSuccess} data={failure<Error, string>(new Error('some test error'))} />
-	))
-	.add('no data', () => <RenderRemoteData success={renderSuccess} data={success('')} noData={data => !data} />);
+storiesOf('RenderRemoteData', module).add('default', () => (
+	<Fragment>
+		<Demo>
+			<RenderRemoteData success={renderSuccess} data={pending} />
+		</Demo>
+		<Demo>
+			<RenderRemoteData success={renderSuccess} data={success('success')} />
+		</Demo>
+		<Demo>
+			<RenderRemoteData success={renderSuccess} data={failure<Error, string>(new Error('some test error'))} />
+		</Demo>
+		<Demo>
+			<RenderRemoteData success={renderSuccess} data={success('')} noData={data => !data} />
+		</Demo>
+	</Fragment>
+));

--- a/packages/react-kit/src/components/render-remote-data/render-remote-data.component.tsx
+++ b/packages/react-kit/src/components/render-remote-data/render-remote-data.component.tsx
@@ -10,6 +10,7 @@ export type TDataStateErrorMainProps<L> = {
 export type TRenderRemoteDataStates<L, FP extends TDataStateErrorMainProps<L>> = {
 	DataStateNoData: ComponentType;
 	DataStateFailure: ComponentType<FP>;
+	DataStatePending: ComponentType;
 };
 
 export type TRenderRemoteDataMainProps<L, D> = {
@@ -28,11 +29,17 @@ export class RenderRemoteData<L, D, FP extends TDataStateErrorMainProps<L>> exte
 		const { data } = this.props;
 		return (
 			<Fragment>
+				{data.isPending() && this.renderPending()}
 				{data.isSuccess() && this.renderSuccess(data.value)}
 				{data.isFailure() && this.renderFailure(data.error)}
 			</Fragment>
 		);
 	}
+
+	private renderPending = () => {
+		const { DataStatePending } = this.props;
+		return <DataStatePending />;
+	};
 
 	private renderSuccess = (data: D) => {
 		const { noData, success, DataStateNoData } = this.props;

--- a/packages/rx-utils/src/create-handler.ts
+++ b/packages/rx-utils/src/create-handler.ts
@@ -1,0 +1,23 @@
+import { Observable, Subject } from 'rxjs';
+import { isNotNullable } from '@devexperts/utils/dist/object';
+import { startWith } from 'rxjs/operators';
+
+export type THandler<A> = {
+	next: (value: A) => void;
+	stream$: Observable<A>;
+};
+export const createHandler = <A>(startValue?: A): THandler<A> => {
+	const stream = new Subject<A>();
+	const next = (value: A) => stream.next(value);
+
+	if (!isNotNullable(startValue)) {
+		return {
+			stream$: stream.asObservable(),
+			next,
+		};
+	}
+	return {
+		stream$: stream.pipe(startWith(startValue)),
+		next,
+	};
+};


### PR DESCRIPTION
render remote data should have pending state

BREAKING CHANGE: pending state is required in `RenderRemoteData` and `getRenderRemoteData`