### PR TITLE
feat(react-kit): fix stateful types

### DIFF
--- a/packages/react-kit/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-kit/src/components/Checkbox/Checkbox.tsx
@@ -9,7 +9,7 @@ import { TControlProps } from '../Control/Control';
 
 export const CHECKBOX = Symbol('Checkbox') as symbol;
 
-export type TFullCheckboxProps = TControlProps<boolean> & {
+export type TFullCheckboxProps = TControlProps<boolean | undefined> & {
 	id?: string;
 	checkMark: React.ReactNode;
 	isDisabled?: boolean;

--- a/packages/react-kit/src/components/Control/Control.ts
+++ b/packages/react-kit/src/components/Control/Control.ts
@@ -74,15 +74,17 @@ export const KEY_CODE_NUM_MAP: { [code: number]: number } = {
 //D - default value prop name (string, default: 'defaultValue')
 //H - change handler prop name (string, default: 'onValueChange')
 
-//state of HOC - no need to mess with value naming - let it just be a 'value'
+/**
+ * state of HOC - no need to mess with value naming - let it just be a 'value'
+ */
 export type TStatefulState<V> = {
 	value?: V;
 };
 
 //first part of props with constraint that props should contain a field with name N (value name) and type V (value type)
-export type TDynamicValue<V, N extends string> = { [value in N]?: V | undefined };
+export type TDynamicValue<V, N extends string> = { [value in N]: V };
 //seconds part of props with constraint that props should contain a field with name H (change handler name) and type H (change handler type)
-export type TDynamicValueHandler<V, H extends string> = { [handler in H]: (value?: V) => void };
+export type TDynamicValueHandler<V, H extends string> = { [handler in H]: (value: V) => void };
 //union of props
 export type TControlProps<V, N extends string = 'value', H extends string = 'onValueChange'> = TDynamicValue<V, N> &
 	TDynamicValueHandler<V, H>;
@@ -94,9 +96,9 @@ export type TStatefulProps<
 	N extends string = 'value',
 	D extends string = 'defaultValue',
 	H extends string = 'onValueChange'
-> = Omit<P, 'value' | N | H> & //remove both value name and handler name from props
+> = Omit<P, N | H> & //remove both value name and handler name from props
 	Partial<TDynamicValueHandler<V, H>> & //add optional change handler to props
-	Partial<TDynamicValue<V, D>>; //add default value name to props - pass D (defaultValue name) here instead of N (value name)
+	TDynamicValue<V, D>; //add default value name to props - pass D (defaultValue name) here instead of N (value name)
 
 //this will the type of resulting HOC
 type TResult<

--- a/packages/react-kit/src/components/Dropdown/Dropdown.page.tsx
+++ b/packages/react-kit/src/components/Dropdown/Dropdown.page.tsx
@@ -45,14 +45,14 @@ const AnchorSFC: SFC<TAnchorProps> = props => {
 storiesOf('Dropdown', module)
 	.add('with class Anchor', () => (
 		<Demo>
-			<StatefulDropdown Anchor={AnchorClass}>
+			<StatefulDropdown defaultValue={undefined} Anchor={AnchorClass}>
 				<div>hi!</div>
 			</StatefulDropdown>
 		</Demo>
 	))
 	.add('with SFC Anchor', () => (
 		<Demo>
-			<StatefulDropdown Anchor={AnchorSFC} onToggle={console.log.bind(console)}>
+			<StatefulDropdown defaultValue={undefined} Anchor={AnchorSFC} onToggle={console.log.bind(console)}>
 				hi
 			</StatefulDropdown>
 		</Demo>
@@ -69,7 +69,7 @@ class DropdownPage extends Component<any, any> {
 	render() {
 		return (
 			<div>
-				<StatefulDropdown Anchor={AnchorClass}>
+				<StatefulDropdown defaultValue={undefined} Anchor={AnchorClass}>
 					<Button onClick={this.onForceCloseClick}>Force close</Button>
 				</StatefulDropdown>
 			</div>

--- a/packages/react-kit/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-kit/src/components/Dropdown/Dropdown.tsx
@@ -15,7 +15,7 @@ export type TAnchorProps = WithInnerRef<{
 	children: ReactNode;
 }>;
 
-export type TFullDropdownProps = TControlProps<boolean, 'isOpened', 'onToggle'> & {
+export type TFullDropdownProps = TControlProps<boolean | undefined, 'isOpened', 'onToggle'> & {
 	Anchor: ComponentType<TAnchorProps>;
 	Popover: ComponentType<TPopoverProps>;
 	theme: {

--- a/packages/react-kit/src/components/Expandable/Expandable.page.tsx
+++ b/packages/react-kit/src/components/Expandable/Expandable.page.tsx
@@ -23,7 +23,7 @@ class CustomHandler extends React.Component<any> {
 
 storiesOf('Expandable', module).add('default', () => (
 	<Demo>
-		<Stateful Handler={CustomHandler}>
+		<Stateful defaultValue={undefined} Handler={CustomHandler}>
 			You will not be asked for further confirmation of trades. <br />
 			Trades will be executed with on click.
 		</Stateful>

--- a/packages/react-kit/src/components/Expandable/Expandable.tsx
+++ b/packages/react-kit/src/components/Expandable/Expandable.tsx
@@ -10,7 +10,7 @@ import { withDefaults } from '../../utils/with-defaults';
 
 export const EXPANDABLE = Symbol('Expandable') as symbol;
 
-export type TFullExpandableProps = TControlProps<boolean | null> & {
+export type TFullExpandableProps = TControlProps<boolean | undefined | null> & {
 	theme: {
 		container?: string;
 		handler?: string;

--- a/packages/react-kit/src/components/Popup/Popup.page.tsx
+++ b/packages/react-kit/src/components/Popup/Popup.page.tsx
@@ -80,7 +80,7 @@ class PopupPage extends React.Component {
 						onRequestClose={this.onPopupRequestClose}
 						isOpened={isOpened}>
 						<div>popup content</div>
-						<Stateful placeholder="Choose your hero">
+						<Stateful defaultValue={undefined} placeholder="Choose your hero">
 							<MenuItem value="superman">Superman</MenuItem>
 							<MenuItem value="batman">Batman</MenuItem>
 							<MenuItem value="flash">Flash</MenuItem>

--- a/packages/react-kit/src/components/Selectbox/Selectbox.page.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.page.tsx
@@ -56,6 +56,7 @@ class SelectboxPage extends React.Component<{}, TPageState> {
 			<Demo>
 				<div>
 					<Stateful
+						defaultValue={undefined}
 						placeholder="Choose your hero"
 						selectedIcon={<ListItemTickIcon />}
 						onValueChange={this.onHeroChange as any}
@@ -75,7 +76,7 @@ class SelectboxPage extends React.Component<{}, TPageState> {
 						<MenuItem value="batman">Batman</MenuItem>
 						<MenuItem value="flash">Flash</MenuItem>
 					</DemoSelectbox>
-					<Stateful placeholder="Loading" isDisabled={true} isLoading={true}>
+					<Stateful defaultValue={undefined} placeholder="Loading" isDisabled={true} isLoading={true}>
 						<MenuItem value="dummy">Dummy</MenuItem>
 					</Stateful>
 					<Button onClick={this.onResetClick}>Reset</Button>
@@ -83,6 +84,7 @@ class SelectboxPage extends React.Component<{}, TPageState> {
 				<section>
 					Sync width
 					<Stateful
+						defaultValue={undefined}
 						placeholder="Choose your hero"
 						shouldSyncWidth={true}
 						theme={wideSelectboxTheme}

--- a/packages/react-kit/src/components/Selectbox/Selectbox.tsx
+++ b/packages/react-kit/src/components/Selectbox/Selectbox.tsx
@@ -15,7 +15,7 @@ import { withDefaults } from '../../utils/with-defaults';
 
 export const SELECTBOX = Symbol('Selectbox') as symbol;
 
-export type TFullSelectboxProps = TControlProps<ReactText> & {
+export type TFullSelectboxProps = TControlProps<ReactText | undefined> & {
 	theme: {
 		container_isOpened?: string;
 		container__popover?: string;

--- a/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
+++ b/packages/react-kit/src/components/SteppableInput/SteppableInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PURE } from '../../utils/pure';
-import { ComponentClass } from 'react';
+import { ComponentClass, ComponentType, ReactElement } from 'react';
 import * as ReactDOM from 'react-dom';
 import { withTheme } from '../../utils/withTheme';
 import { PartialKeys } from '@devexperts/utils/dist/object/object';
@@ -9,6 +9,7 @@ import { Input, TInputProps } from '../input/Input';
 import { KeyCode } from '../Control/Control';
 import { Holdable } from '../Holdable/Holdable';
 import { withDefaults } from '../../utils/with-defaults';
+import { constUndefined } from 'fp-ts/lib/function';
 
 export const STEPPABLE_INPUT = Symbol('SteppableInput') as symbol;
 
@@ -20,12 +21,12 @@ export type TFullSteppableInputProps = TPickedInputProps & {
 	onIncrement?: Function;
 	onDecrement?: Function;
 	onClear?: Function;
-	incrementIcon?: React.ReactElement<any>;
-	decrementIcon?: React.ReactElement<any>;
-	clearIcon?: React.ReactElement<any>;
+	incrementIcon?: ReactElement<any>;
+	decrementIcon?: ReactElement<any>;
+	clearIcon?: ReactElement<any>;
 	children?: any;
-	Input: React.ComponentClass<TInputProps> | React.SFC<TInputProps>;
-	ButtonIcon: React.ComponentClass<TButtonIconProps> | React.SFC<TButtonIconProps>;
+	Input: ComponentType<TInputProps>;
+	ButtonIcon: ComponentType<TButtonIconProps>;
 	theme: {
 		inner?: string;
 		Input?: TInputProps['theme'];
@@ -72,6 +73,8 @@ class RawSteppableInput extends React.Component<TFullSteppableInputProps, TStepp
 
 		return (
 			<Input
+				value={undefined}
+				onValueChange={constUndefined}
 				theme={theme.Input}
 				type="hidden"
 				onFocus={this.onFocus}
@@ -81,7 +84,6 @@ class RawSteppableInput extends React.Component<TFullSteppableInputProps, TStepp
 				onWheel={this.onWheel}
 				isDisabled={isDisabled}
 				error={error}
-				onValueChange={() => console.log('onchange')}
 				tabIndex={isFocused || isDisabled ? -1 : tabIndex || 0}>
 				<div className={theme.inner}>
 					{children}

--- a/packages/react-kit/src/components/TimeInput/TimeInput.tsx
+++ b/packages/react-kit/src/components/TimeInput/TimeInput.tsx
@@ -20,7 +20,7 @@ export enum ActiveSection {
 	Minutes,
 }
 
-export type TTimeInputOwnProps = TSteppableInputProps & TControlProps<TTime | null>;
+export type TTimeInputOwnProps = TSteppableInputProps & TControlProps<TTime | undefined | null>;
 
 export type TTimeInputFullProps = TTimeInputOwnProps & {
 	SteppableInput: React.ComponentClass<TSteppableInputProps> | React.SFC<TSteppableInputProps>;

--- a/packages/react-kit/src/components/input/Input.tsx
+++ b/packages/react-kit/src/components/input/Input.tsx
@@ -16,7 +16,7 @@ import { withTheme } from '../../utils/withTheme';
 
 export const INPUT = Symbol('Input') as symbol;
 
-export type TFullInputProps = TControlProps<string> & {
+export type TFullInputProps = TControlProps<string | undefined> & {
 	min?: any;
 	max?: any;
 	isDisabled?: boolean;


### PR DESCRIPTION
This PR fixes `stateful` types which previously accepted `undefined` by default. Also strict `defaultValue` is not added to resulting component because previously missing `defaultValue` wasn't tracked for components with strict value type which lead to runtime errors.