### PR TITLE
fix(rx-utils): switchMapRD fix

### DIFF
--- a/packages/rx-utils/src/rd/operators/switchMapRD.ts
+++ b/packages/rx-utils/src/rd/operators/switchMapRD.ts
@@ -9,7 +9,7 @@ export function switchMapRD<L, A, B>(f: Function1<A, Observable<RemoteData<L, B>
 			if (data.isSuccess()) {
 				return f(data.value);
 			} else {
-				return of(source);
+				return of(data as any);
 			}
 		})(source);
 	};


### PR DESCRIPTION
switchMapRD operator now returns correct observable for RemoteInitial, RemotePending and RemoteFailure cases