### PR TITLE
fix(rx-utils): remove unnecessary argument from THandler<A>['handle']

### DIFF
--- a/packages/rx-utils/src/create-handler.utils.ts
+++ b/packages/rx-utils/src/create-handler.utils.ts
@@ -1,15 +1,16 @@
 import { Observable, Subject } from 'rxjs';
 
 export type THandler<A> = {
-	handle: (value: A) => void;
-	value$: Observable<A>;
+	readonly handle: A extends void ? () => void : (value: A) => void;
+	readonly value$: Observable<A>;
 };
-export const createHandler = <A>(): THandler<A> => {
+
+export const createHandler = <A = void>(): THandler<A> => {
 	const value = new Subject<A>();
 	const handle = (val: A) => value.next(val);
 
 	return {
 		value$: value.asObservable(),
 		handle,
-	};
+	} as any;
 };


### PR DESCRIPTION
BREAKING CHANGE: call to THandler<void>['handle'](undefined) is now invalid and throw compile-time error