### PR TITLE
feat(react-kit): accept defaultProps in withrx selector result

### DIFF
--- a/packages/react-kit/src/utils/__tests__/with-rx2.spec.tsx
+++ b/packages/react-kit/src/utils/__tests__/with-rx2.spec.tsx
@@ -121,6 +121,7 @@ describe('withRX2', () => {
 		const C3 = withRX(Foo, () => ({ defaultProps: { foo: '123', bar: 213 } }), { scheduler });
 		(() => [
 			<C handler={constUndefined} foo={'123'} bar={123} />,
+			<C1 foo={'123'} bar={123} />,
 			<C1 foo={'123'} bar={123} handler={constUndefined} />,
 			<C2 handler={constUndefined} bar={123} />,
 			<C3 handler={constUndefined} />,

--- a/packages/react-kit/src/utils/__tests__/with-rx2.spec.tsx
+++ b/packages/react-kit/src/utils/__tests__/with-rx2.spec.tsx
@@ -29,8 +29,7 @@ describe('withRX2', () => {
 			result$.next(props.foo);
 			return <div>{props.foo}</div>;
 		};
-		const FooContainer = withRX(
-			Foo,
+		const FooContainer = withRX(Foo)(
 			() => ({
 				props: {
 					foo: foo$,
@@ -51,7 +50,7 @@ describe('withRX2', () => {
 			}
 		}
 		const handler = jest.fn();
-		const FooContainer = withRX(Foo, () => ({ defaultProps: { handler } }));
+		const FooContainer = withRX(Foo)(() => ({ defaultProps: { handler } }));
 		const foo = mount(<FooContainer foo={'test'} />);
 		foo.find('#id').simulate('click');
 		expect(handler).toHaveBeenCalledWith('test');
@@ -59,7 +58,7 @@ describe('withRX2', () => {
 	});
 	it('should pass defaultValues', () => {
 		const Foo: SFC<FooProps> = props => <div id={'foo'}>{props.foo}</div>;
-		const FooContainer = withRX(Foo, () => ({ defaultProps: { foo: 'default' } }));
+		const FooContainer = withRX(Foo)(() => ({ defaultProps: { foo: 'default' } }));
 		const foo = mount(<FooContainer />);
 		expect(foo.find('#foo').text()).toBe('default');
 		foo.unmount();
@@ -67,8 +66,7 @@ describe('withRX2', () => {
 	it('should immediately unsubscribe on unmount', () => {
 		const Foo: SFC<FooProps> = props => <div id={'foo'}>{props.foo}</div>;
 		const foo$ = scheduler.createHotObservable<string>('^-a-b-|');
-		const FooContainer = withRX(
-			Foo,
+		const FooContainer = withRX(Foo)(
 			props$ => ({
 				props: {
 					foo: foo$,
@@ -87,8 +85,7 @@ describe('withRX2', () => {
 			res: '-a-b-|',
 		};
 		const effects$ = scheduler.createColdObservable(timeline.src);
-		const FooContainer = withRX(
-			Foo,
+		const FooContainer = withRX(Foo)(
 			() => ({
 				effects$,
 			}),
@@ -103,7 +100,7 @@ describe('withRX2', () => {
 	it('should immediately unsubscribe from effects on unmount', () => {
 		const Foo = () => <div />;
 		const effects$ = scheduler.createColdObservable('-a-b-|');
-		const FooContainer = withRX(Foo, () => ({ effects$ }), { scheduler });
+		const FooContainer = withRX(Foo)(() => ({ effects$ }), { scheduler });
 		const foo = mount(<FooContainer />);
 		foo.unmount();
 		scheduler.expectSubscriptions(effects$.subscriptions).toBe('(^!)');
@@ -115,16 +112,19 @@ describe('withRX2', () => {
 			handler: (arg: number) => void;
 		};
 		const Foo: SFC<Props> = () => <div>hi</div>;
-		const C = withRX(Foo, () => ({}), { scheduler });
-		const C1 = withRX(Foo, () => ({ defaultProps: { handler: constUndefined } }), { scheduler });
-		const C2 = withRX(Foo, () => ({ defaultProps: { foo: '123', adsfsd: 123 } }), { scheduler });
-		const C3 = withRX(Foo, () => ({ defaultProps: { foo: '123', bar: 213 } }), { scheduler });
+		const C = withRX(Foo)(() => ({}), { scheduler });
+		const C1 = withRX(Foo)(() => ({ defaultProps: { handler: constUndefined } }), { scheduler });
+		const C2 = withRX(Foo)(() => ({ defaultProps: { foo: '123', adsfsd: 123 } }), { scheduler });
+		const C3 = withRX(Foo)(() => ({ defaultProps: { foo: '123', bar: 213 } }), { scheduler });
+		//argument inference is working
+		const C4 = withRX(Foo)(() => ({ defaultProps: { handler(arg) {} } }), { scheduler });
 		(() => [
 			<C handler={constUndefined} foo={'123'} bar={123} />,
 			<C1 foo={'123'} bar={123} />,
 			<C1 foo={'123'} bar={123} handler={constUndefined} />,
 			<C2 handler={constUndefined} bar={123} />,
 			<C3 handler={constUndefined} />,
+			<C4 foo={'123'} bar={123} />,
 		])();
 	});
 });

--- a/packages/react-kit/src/utils/with-rx2.ts
+++ b/packages/react-kit/src/utils/with-rx2.ts
@@ -19,11 +19,14 @@ export type WithRXOptions = {
 	scheduler?: SchedulerLike;
 };
 
-export function withRX<P extends object, D extends Partial<P>>(
-	Target: ComponentType<P>,
+/**
+ * curried for better type inference
+ * @see https://github.com/Microsoft/TypeScript/issues/15005#issuecomment-430588884
+ */
+export const withRX = <P extends object>(Target: ComponentType<P>) => <D extends Partial<P>>(
 	selector: (props$: Observable<Readonly<P>>) => WithRXSelectorResult<P, D>,
 	options: WithRXOptions = {},
-): ComponentClass<Omit<P, keyof D> & Partial<D>> {
+): ComponentClass<Omit<P, keyof D> & Partial<D>> => {
 	const scheduler = options.scheduler || animationFrame;
 
 	class WithRX extends PureComponent<P, Partial<P>> {
@@ -66,4 +69,4 @@ export function withRX<P extends object, D extends Partial<P>>(
 	hoistNonReactStatics(WithRX, Target);
 
 	return WithRX as any; //defaultProps are tracked by defaultProps argument;
-}
+};


### PR DESCRIPTION
This allows to pass handlers along with props in WithRXSelector

**BREAKING CHANGES:** 
- `defaultProps` argument is moved to `WithRXSelectorResult`; 
- `static defaultProps` property is removed; 
- `props$` stream passed to `selector` doesn't contain fields from `defaultProps` anymore
- `withRX` now accepts `Target` separately for better type inference in `props`/`defaultProps`