### PR TITLE
Fix combine context type

### DIFF
--- a/packages/rx-utils/src/context.utils.ts
+++ b/packages/rx-utils/src/context.utils.ts
@@ -170,7 +170,9 @@ export interface CombineContext {
 	): Context<EA & EB & EC & ED & EE & EG & EH & EI & EJ & EK & EL, R>;
 }
 export type ProjectMany<A, R> = (...args: A[]) => R;
-export const combineContext: CombineContext = <E, A, R>(...args: Array<Context<E, A> | ProjectMany<A, R | Sink<R>>>) => {
+export const combineContext: CombineContext = <E, A, R>(
+	...args: Array<Context<E, A> | ProjectMany<A, R | Sink<R>>>
+) => {
 	const fas: Context<E, A>[] = args.slice(0, args.length - 1) as any; //typesafe
 	const project: ProjectMany<A, R | Sink<R>> = args[args.length - 1] as any; //typesafe
 	const sequenced: Context<E, A[]> = sequenceContext(fas);

--- a/packages/rx-utils/src/context.utils.ts
+++ b/packages/rx-utils/src/context.utils.ts
@@ -170,7 +170,7 @@ export interface CombineContext {
 	): Context<EA & EB & EC & ED & EE & EG & EH & EI & EJ & EK & EL, R>;
 }
 export type ProjectMany<A, R> = (...args: A[]) => R;
-export const combineContext: CombineContext = <E, A, R>(...args: Array<A | ProjectMany<A, R | Sink<R>>>) => {
+export const combineContext: CombineContext = <E, A, R>(...args: Array<Context<E, A> | ProjectMany<A, R | Sink<R>>>) => {
 	const fas: Context<E, A>[] = args.slice(0, args.length - 1) as any; //typesafe
 	const project: ProjectMany<A, R | Sink<R>> = args[args.length - 1] as any; //typesafe
 	const sequenced: Context<E, A[]> = sequenceContext(fas);


### PR DESCRIPTION
I've found small typo in type of the `combineContext`. Although project is well typed anyway because of coercion, I propose the fix just for documentation purposes and for further development (if you intend to avoid coercions).

The typo is about using simple `A` in array of arguments, however the arguments have a type of `Context<E, A>`